### PR TITLE
Fix 1.13.0, 1.13.1 - classes not fully decompiling

### DIFF
--- a/versions/1.13.1/config.json
+++ b/versions/1.13.1/config.json
@@ -6,7 +6,7 @@
     "fernflower": {
         "version": "net.minecraftforge:forgeflower:1.5.380.22",
         "args": ["-din=1", "-rbr=1", "-dgs=1", "-asc=1", "-rsy=1", "-iec=1", "-jvn=1", "-log=TRACE", "-cfg", "{libraries}", "{input}", "{output}"],
-        "jvmargs": []
+        "jvmargs": ["-Xmx4G"]
     },
     "merge": {
         "version": "net.minecraftforge:mergetool:1.0.1:fatjar",

--- a/versions/1.13/config.json
+++ b/versions/1.13/config.json
@@ -6,7 +6,7 @@
     "fernflower": {
         "version": "net.minecraftforge:forgeflower:1.5.380.20",
         "args": ["-din=1", "-rbr=1", "-dgs=1", "-asc=1", "-rsy=1", "-iec=1", "-jvn=1", "-log=TRACE", "-cfg", "{libraries}", "{input}", "{output}"],
-        "jvmargs": []
+        "jvmargs": ["-Xmx4G"]
     },
     "merge": {
         "version": "net.minecraftforge:mergetool:1.0.1:fatjar",


### PR DESCRIPTION
Systems with smaller amounts of ram do not allocate enough ram for Fernflower to successfully decompile all of the classes resulting in null pointer exceptions during builds. This was fixed for 1.13.2 with commit [2d1b271](https://github.com/MinecraftForge/MCPConfig/commit/2d1b27131651897791bdee0f1574f76467f7ebb0) but not for 1.13.0 and 1.13.1. I have added 4G to both configs JVM arguments to fix this.