### PR TITLE
[WIP] Transition MCPConfig to use Mojang mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ subprojects {
         PATH_INJECT = file('inject').exists() ? file('inject') : null
         PATH_INJECT_TEMPLATE = PATH_INJECT == null || !new File(PATH_INJECT, 'package-info-template.java').exists() ? null : new File(PATH_INJECT, 'package-info-template.java')
         PROJECT_TEMPLATE = file('project_template.gradle').exists() ? file('project_template.gradle') : rootProject.file('project_template.gradle')
-        PATH_TSRG = PATH_VERSION + 'joined.tsrg'
+        PATH_TSRG = PATH_BUILD + '/versions/' + project.version + '/mappings.tsrg'
         PATH_ASSETS = PATH_BUILD + '/assets'
         PATH_NATIVES = PATH_VERSION + 'natives'
         

--- a/build.gradle
+++ b/build.gradle
@@ -368,7 +368,7 @@ subprojects {
         archiveName = project.version + '.client.slim.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadClient.dest)
-        doLast {
+        doFirst {
             loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
         }
     }
@@ -376,7 +376,7 @@ subprojects {
         archiveName = project.version + '.client.extra.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadClient.dest)
-        doLast {
+        doFirst {
             loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
         }
     }
@@ -384,7 +384,7 @@ subprojects {
         archiveName = project.version + '.server.slim.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadServer.dest)
-        doLast {
+        doFirst {
             loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
         }
     }
@@ -392,7 +392,7 @@ subprojects {
         archiveName = project.version + '.server.extra.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadServer.dest)
-        doLast {
+        doFirst {
             loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
         }
     }
@@ -412,7 +412,7 @@ subprojects {
         jar downloadRenameTool.dest
         jvmArgs RENAMETOOL.jvmargs
         input filterClient.archivePath
-        mappings file(PATH_VERSION + 'joined.tsrg')
+        mappings file(PATH_TSRG)
         args RENAMETOOL.args
         dest file(PATH_CACHED_VERSION + project.version + '.client.mapped.jar')
     }
@@ -420,7 +420,7 @@ subprojects {
         jar downloadRenameTool.dest
         jvmArgs RENAMETOOL.jvmargs
         input filterServer.archivePath
-        mappings file(PATH_VERSION + 'joined.tsrg')
+        mappings file(PATH_TSRG)
         args RENAMETOOL.args
         dest file(PATH_CACHED_VERSION + project.version + '.server.mapped.jar')
     }
@@ -428,7 +428,7 @@ subprojects {
         jar downloadRenameTool.dest
         jvmArgs RENAMETOOL.jvmargs
         input mergeJars.dest
-        mappings file(PATH_VERSION + 'joined.tsrg')
+        mappings file(PATH_TSRG)
         args RENAMETOOL.args
         dest file(PATH_CACHED_VERSION + project.version + '.joined.mapped.jar')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,8 @@ def findFull(year, week) {
         return '1.13'
     if (value >= 1830 && value <= 1833)
         return '1.13.1'
+	if (value >= 1934)
+		return '1.15'
     throw new RuntimeException('Unknown week range: ' + value)
 }
 def splitWeekly(ver) {
@@ -237,6 +239,15 @@ subprojects {
         dest file(PATH_CACHED_VERSION + project.version + '.client.jar')
         overwrite false
     }
+	task downloadClientMappings(type: Download, dependsOn: downloadJson) {
+		inputs.file downloadJson.dest
+		doFirst {
+			def json = new JsonSlurper().parseText(inputs.files.singleFile.text)
+			downloadClientMappings.src json.downloads.client_mappings?.url
+		}
+		dest file(PATH_CACHED_VERSION + project.version + '.client.txt')
+		overwrite false
+	}
     task downloadServer(type: Download, dependsOn: downloadJson) {
         inputs.file downloadJson.dest
         doFirst {
@@ -246,6 +257,15 @@ subprojects {
         dest file(PATH_CACHED_VERSION + project.version + '.server.jar')
         overwrite false
     }
+	task downloadServerMappings(type: Download, dependsOn: downloadJson) {
+		inputs.file downloadJson.dest
+		doFirst {
+			def json = new JsonSlurper().parseText(inputs.files.singleFile.text)
+			downloadServerMappings.src json.downloads.server_mappings?.url
+		}
+		dest file(PATH_CACHED_VERSION + project.version + '.server.txt')
+		overwrite false
+	}
     task downloadLibraries(dependsOn: downloadJson) {
         inputs.file downloadJson.dest
         doLast {
@@ -333,30 +353,46 @@ subprojects {
             overwrite false
         }
     }
+	
+	task convertMappings(type: ConvertMappings, dependsOn: [downloadClientMappings]) {
+		doFirst {
+			proguard file(downloadClientMappings.dest)
+			tsrg file(PATH_TSRG) // server mappings are subset of client mappings, so no joining needed
+			overwrite false
+		}
+	}
     
-    task filterClient(type: Zip, dependsOn: [downloadClient]) {
+    task filterClient(type: Zip, dependsOn: [downloadClient, convertMappings]) {
         archiveName = project.version + '.client.slim.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadClient.dest)
-        loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
+		doLast {
+			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
+		}
     }
-    task filterClientExtra(type: Zip, dependsOn: [downloadClient]) {
+    task filterClientExtra(type: Zip, dependsOn: [downloadClient, convertMappings]) {
         archiveName = project.version + '.client.extra.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadClient.dest)
-        loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
+		doLast {
+			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
+		}
     }
-    task filterServer(type: Zip, dependsOn: [downloadServer]) {
+    task filterServer(type: Zip, dependsOn: [downloadServer, convertMappings]) {
         archiveName = project.version + '.server.slim.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadServer.dest)
-        loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
+		doLast {
+			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
+		}
     }
-    task filterServerExtra(type: Zip, dependsOn: [downloadServer]) {
+    task filterServerExtra(type: Zip, dependsOn: [downloadServer, convertMappings]) {
         archiveName = project.version + '.server.extra.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadServer.dest)
-        loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
+		doLast {
+			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
+		}
     }
     task filterJars(dependsOn: [filterClient, filterClientExtra, filterServer, filterServerExtra]){}
     

--- a/build.gradle
+++ b/build.gradle
@@ -112,8 +112,8 @@ def findFull(year, week) {
         return '1.13'
     if (value >= 1830 && value <= 1833)
         return '1.13.1'
-	if (value >= 1934)
-		return '1.15'
+    if (value >= 1934)
+        return '1.15'
     throw new RuntimeException('Unknown week range: ' + value)
 }
 def splitWeekly(ver) {
@@ -239,15 +239,15 @@ subprojects {
         dest file(PATH_CACHED_VERSION + project.version + '.client.jar')
         overwrite false
     }
-	task downloadClientMappings(type: Download, dependsOn: downloadJson) {
-		inputs.file downloadJson.dest
-		doFirst {
-			def json = new JsonSlurper().parseText(inputs.files.singleFile.text)
-			downloadClientMappings.src json.downloads.client_mappings?.url
-		}
-		dest file(PATH_CACHED_VERSION + project.version + '.client.txt')
-		overwrite false
-	}
+    task downloadClientMappings(type: Download, dependsOn: downloadJson) {
+        inputs.file downloadJson.dest
+        doFirst {
+            def json = new JsonSlurper().parseText(inputs.files.singleFile.text)
+            downloadClientMappings.src json.downloads.client_mappings?.url
+        }
+        dest file(PATH_CACHED_VERSION + project.version + '.client.txt')
+        overwrite false
+    }
     task downloadServer(type: Download, dependsOn: downloadJson) {
         inputs.file downloadJson.dest
         doFirst {
@@ -257,15 +257,15 @@ subprojects {
         dest file(PATH_CACHED_VERSION + project.version + '.server.jar')
         overwrite false
     }
-	task downloadServerMappings(type: Download, dependsOn: downloadJson) {
-		inputs.file downloadJson.dest
-		doFirst {
-			def json = new JsonSlurper().parseText(inputs.files.singleFile.text)
-			downloadServerMappings.src json.downloads.server_mappings?.url
-		}
-		dest file(PATH_CACHED_VERSION + project.version + '.server.txt')
-		overwrite false
-	}
+    task downloadServerMappings(type: Download, dependsOn: downloadJson) {
+        inputs.file downloadJson.dest
+        doFirst {
+            def json = new JsonSlurper().parseText(inputs.files.singleFile.text)
+            downloadServerMappings.src json.downloads.server_mappings?.url
+        }
+        dest file(PATH_CACHED_VERSION + project.version + '.server.txt')
+        overwrite false
+    }
     task downloadLibraries(dependsOn: downloadJson) {
         inputs.file downloadJson.dest
         doLast {
@@ -353,46 +353,46 @@ subprojects {
             overwrite false
         }
     }
-	
-	task convertMappings(type: ConvertMappings, dependsOn: [downloadClientMappings]) {
-		doFirst {
-			proguard file(downloadClientMappings.dest)
-			tsrg file(PATH_TSRG) // server mappings are subset of client mappings, so no joining needed
-			overwrite false
-		}
-	}
+    
+    task convertMappings(type: ConvertMappings, dependsOn: [downloadClientMappings]) {
+        doFirst {
+            proguard file(downloadClientMappings.dest)
+            tsrg file(PATH_TSRG) // server mappings are subset of client mappings, so no joining needed
+            overwrite false
+        }
+    }
     
     task filterClient(type: Zip, dependsOn: [downloadClient, convertMappings]) {
         archiveName = project.version + '.client.slim.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadClient.dest)
-		doLast {
-			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
-		}
+        doLast {
+            loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
+        }
     }
     task filterClientExtra(type: Zip, dependsOn: [downloadClient, convertMappings]) {
         archiveName = project.version + '.client.extra.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadClient.dest)
-		doLast {
-			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
-		}
+        doLast {
+            loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
+        }
     }
     task filterServer(type: Zip, dependsOn: [downloadServer, convertMappings]) {
         archiveName = project.version + '.server.slim.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadServer.dest)
-		doLast {
-			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
-		}
+        doLast {
+            loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ include it + '.class' }
+        }
     }
     task filterServerExtra(type: Zip, dependsOn: [downloadServer, convertMappings]) {
         archiveName = project.version + '.server.extra.jar'
         destinationDir = file(PATH_CACHED_VERSION)
         from zipTree(downloadServer.dest)
-		doLast {
-			loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
-		}
+        doLast {
+            loadSRG(file(PATH_TSRG))['CL:'].keySet().each{ exclude it + '.class' }
+        }
     }
     task filterJars(dependsOn: [filterClient, filterClientExtra, filterServer, filterServerExtra]){}
     

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,8 @@ def findFull(year, week) {
         return '1.13'
     if (value >= 1830 && value <= 1833)
         return '1.13.1'
+    if (value >= 1843 && value <= 1914)
+        return '1.14'
     if (value >= 1934)
         return '1.15'
     throw new RuntimeException('Unknown week range: ' + value)
@@ -151,7 +153,7 @@ subprojects {
         PATH_INJECT = file('inject').exists() ? file('inject') : null
         PATH_INJECT_TEMPLATE = PATH_INJECT == null || !new File(PATH_INJECT, 'package-info-template.java').exists() ? null : new File(PATH_INJECT, 'package-info-template.java')
         PROJECT_TEMPLATE = file('project_template.gradle').exists() ? file('project_template.gradle') : rootProject.file('project_template.gradle')
-        PATH_TSRG = PATH_BUILD + '/versions/' + project.version + '/mappings.tsrg'
+        PATH_TSRG = PATH_CACHED_VERSION + 'mappings.tsrg'
         PATH_ASSETS = PATH_BUILD + '/assets'
         PATH_NATIVES = PATH_VERSION + 'natives'
         

--- a/buildSrc/src/main/java/net/minecraftforge/mcpconfig/tasks/ConvertMappings.java
+++ b/buildSrc/src/main/java/net/minecraftforge/mcpconfig/tasks/ConvertMappings.java
@@ -19,30 +19,30 @@ import org.gradle.api.tasks.TaskAction;
 public class ConvertMappings extends DefaultTask {
 
     private File proguard;
-	
-	public void proguard(Object o) {
-		this.proguard = (File) o;
-	}
+    
+    public void proguard(Object o) {
+        this.proguard = (File) o;
+    }
 
     private File tsrg;
-	
-	public void tsrg(Object o) {
-		this.tsrg = (File) o;
-	}
-	
-	private boolean overwrite = false;
-	
-	public void overwrite(Object o) {
-		this.overwrite = (Boolean) o;
-	}
+    
+    public void tsrg(Object o) {
+        this.tsrg = (File) o;
+    }
+    
+    private boolean overwrite = false;
+    
+    public void overwrite(Object o) {
+        this.overwrite = (Boolean) o;
+    }
 
     private Map<String, String> classMap = new HashMap<>();
 
     @TaskAction
     public void doTask() throws IOException {
         loadClasses();
-		if(!tsrg.exists() || overwrite)
-			tsrg.createNewFile();
+        if(!tsrg.exists() || overwrite)
+            tsrg.createNewFile();
         writeTsrg();
     }
 

--- a/buildSrc/src/main/java/net/minecraftforge/mcpconfig/tasks/ConvertMappings.java
+++ b/buildSrc/src/main/java/net/minecraftforge/mcpconfig/tasks/ConvertMappings.java
@@ -1,0 +1,148 @@
+package net.minecraftforge.mcpconfig.tasks;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+public class ConvertMappings extends DefaultTask {
+
+    private File proguard;
+	
+	public void proguard(Object o) {
+		this.proguard = (File) o;
+	}
+
+    private File tsrg;
+	
+	public void tsrg(Object o) {
+		this.tsrg = (File) o;
+	}
+	
+	private boolean overwrite = false;
+	
+	public void overwrite(Object o) {
+		this.overwrite = (Boolean) o;
+	}
+
+    private Map<String, String> classMap = new HashMap<>();
+
+    @TaskAction
+    public void doTask() throws IOException {
+        loadClasses();
+		if(!tsrg.exists() || overwrite)
+			tsrg.createNewFile();
+        writeTsrg();
+    }
+
+    // can only be called after #loadClasses or class parameters will not get obfuscated
+    private String typeToDescriptor(String type) {
+        if(type.endsWith("[]")) // array type
+            return "[" + typeToDescriptor(type.substring(0, type.length() - 2));
+        if(type.contains("."))  // class type
+            return "L" + classMap.getOrDefault(type, type).replaceAll("\\.", "/") + ";";
+
+        switch(type) { // primitive type
+            case    "byte": return "B";
+            case    "char": return "C";
+            case  "double": return "D";
+            case   "float": return "F";
+            case     "int": return "I";
+            case    "long": return "J";
+            case   "short": return "S";
+            case    "void": return "V";
+            case "boolean": return "Z";
+            default: return "";
+        }
+    }
+
+    private void loadClasses() throws IOException {
+        BufferedReader reader = new BufferedReader(new FileReader(proguard));
+
+        while(true) {
+            String line = reader.readLine();
+            if (line == null || line.isEmpty()) break; // end of file
+
+            if (line.startsWith("#")) continue; // comment line
+
+            if (line.startsWith(" ")) continue; // field or method line
+
+            String parts[] = line.split(" ");
+            assert parts.length == 3; // [<class name>],[->],[<obfuscated name>:]
+
+            String className = parts[0];
+            String obfName   = parts[2].substring(0, parts[2].length() - 1); // strip colon
+
+            classMap.put(className, obfName);
+        }
+
+        reader.close();
+    }
+
+    private void writeTsrg() throws IOException {
+        BufferedReader reader = new BufferedReader(new FileReader(proguard));
+        BufferedWriter writer = new BufferedWriter(new FileWriter(tsrg));
+
+        while(true) {
+            String line = reader.readLine();
+            if (line == null || line.isEmpty()) break; // end of file
+
+            if (line.startsWith("#")) continue; // comment line
+
+            if (line.startsWith(" ")) { // field or method line
+                line = line.substring(4); // remove leading spaces
+
+                String parts[] = line.split(" ");
+                assert parts.length == 4; // [<type>],[<name>],[->],[<obfuscated name>]
+
+                if(parts[1].endsWith(")")) { // method line
+                    String returnType = parts[0].contains(":")
+                        ? parts[0].split(":")[2] // [<#>],[<#>],[<type>]
+                        : parts[0];
+
+                    String obfName    = parts[3];
+                    String methodName = parts[1].split("\\(")[0]; // [<name>],[<params...>)]
+                    String params     = parts[1].split("\\(")[1];
+                    params = params.substring(0, params.length() - 1); // strip ) from params
+
+                    returnType = typeToDescriptor(returnType);
+                    params = Arrays.stream(params.split(",")) // [<param>],[<param>], ...
+                        .map(this::typeToDescriptor)
+                        .collect(Collectors.joining());
+
+                    if(methodName.equals("<init>") || methodName.equals("<clinit>")) continue;
+
+                    writer.write(String.format("\t%s (%s)%s %s\n", obfName, params, returnType, methodName));
+                } else { // field line
+                    String fieldName = parts[1];
+                    String obfName   = parts[3];
+
+                    writer.write("\t" + obfName + " " + fieldName + "\n");
+                }
+            } else { // class line
+                String parts[] = line.split(" ");
+                assert parts.length == 3; // [<class name>],[->],[<obfuscated name>:]
+
+                String className = parts[0];
+                String obfName   = parts[2].substring(0, parts[2].length() - 1); // strip colon
+
+                writer.write(new String(obfName + " " + className + "\n").replaceAll("\\.","/"));
+            }
+        }
+
+        writer.close();
+        reader.close();
+    }
+
+}

--- a/meta_cache.json
+++ b/meta_cache.json
@@ -168,6 +168,9 @@
         "json": "https://launchermeta.mojang.com/v1/packages/c69051042abf0340dce2e00723902e85a3d23d12/1.14.4-pre7.json"
     },
     "1.14.4": {
-        "json": "https://launchermeta.mojang.com/v1/packages/f88bed9cd129ddcd40942dac129604262d8b77ca/1.14.4.json"
+        "json": "https://launchermeta.mojang.com/v1/packages/74b5fb5fa9ec7b14abe60b468e40703cfbf8d10e/1.14.4.json"
+    },
+    "19w36a": {
+        "json": "https://launchermeta.mojang.com/v1/packages/01cc2e7f8355299240f4674f2de1619906c21302/19w36a.json"
     }
 }

--- a/versions/19w36a/config.json
+++ b/versions/19w36a/config.json
@@ -1,0 +1,26 @@
+{
+    "mcinjector": {
+        "version": "de.oceanlabs.mcp:mcinjector:3.7.7:fatjar",
+        "args": ["--in", "{input}", "--out", "{output}", "--log", "{log}", "--level=INFO", "--lvt=LVT", "--exc", "{exceptions}", "--acc", "{access}", "--ctr", "{constructors}"]
+    },
+    "fernflower": {
+        "version": "net.minecraftforge:forgeflower:1.5.380.33",
+        "args": ["-din=1", "-rbr=1", "-dgs=1", "-asc=1", "-rsy=1", "-iec=1", "-jvn=1", "-log=TRACE", "-cfg", "{libraries}", "{input}", "{output}"],
+        "jvmargs": ["-Xmx4G"]
+    },
+    "merge": {
+        "version": "net.minecraftforge:mergetool:1.0.9:fatjar",
+        "args": ["--client", "{client}", "--server", "{server}", "--ann", "{version}", "--output", "{output}", "--inject", "false"],
+        "jvmargs": []
+    },
+    "rename": {
+        "version": "net.md-5:SpecialSource:1.8.4:shaded",
+        "args": ["--in-jar", "{input}", "--out-jar", "{output}", "--srg-in", "{mappings}"],
+        "repo": "http://repo1.maven.org/maven2/"
+    },
+    "libraries": {
+        "client": ["com.google.code.findbugs:jsr305:3.0.1"],
+        "server": ["com.google.code.findbugs:jsr305:3.0.1"],
+        "joined": ["com.google.code.findbugs:jsr305:3.0.1", "net.minecraftforge:mergetool:1.0.9:api"]
+    }
+}


### PR DESCRIPTION
See: #39 

As it stands, I've started the process of modifying MCPConfig to download the Mojang mappings and automatically apply them.

Either way, here is my task list:
- [x] Add mapping download
- [x] Add mapping conversion
- [ ] Determine how `constructors.txt` works and see if it needs to be updated
- [ ] Allow the two mapping types to live in harmony (right now if run on a version without Mojang mappings there will be an NPE)
- [x] Move mappings from `/versions/x` to `/build/versions/x` since they are not redistributable