### PR TITLE
Fix some lambdas having a bouncer method in the inheritance json

### DIFF
--- a/buildSrc/src/main/java/net/minecraftforge/lex/ExtractInheritance.java
+++ b/buildSrc/src/main/java/net/minecraftforge/lex/ExtractInheritance.java
@@ -346,7 +346,7 @@ public class ExtractInheritance extends DefaultTask
             this.parent = parent;
             Bouncer bounce = null;
             
-            if ((node.access & (ACC_SYNTHETIC | ACC_BRIDGE)) != 0 && (node.access & ACC_STATIC) == 0 && (node.access & ACC_PRIVATE) == 0)
+            if ((node.access & (ACC_SYNTHETIC | ACC_BRIDGE)) != 0 && (node.access & (ACC_STATIC | ACC_PRIVATE)) == 0)
             {
                 AbstractInsnNode start = node.instructions.getFirst();
                 if (start instanceof LabelNode && start.getNext() instanceof LineNumberNode)

--- a/buildSrc/src/main/java/net/minecraftforge/lex/ExtractInheritance.java
+++ b/buildSrc/src/main/java/net/minecraftforge/lex/ExtractInheritance.java
@@ -346,7 +346,7 @@ public class ExtractInheritance extends DefaultTask
             this.parent = parent;
             Bouncer bounce = null;
             
-            if ((node.access & (ACC_SYNTHETIC | ACC_BRIDGE)) != 0 && (node.access & ACC_STATIC) == 0)
+            if ((node.access & (ACC_SYNTHETIC | ACC_BRIDGE)) != 0 && (node.access & ACC_STATIC) == 0 && (node.access & ACC_PRIVATE) == 0)
             {
                 AbstractInsnNode start = node.instructions.getFirst();
                 if (start instanceof LabelNode && start.getNext() instanceof LineNumberNode)


### PR DESCRIPTION
Some lambda methods were still getting through the bouncer method check and basically throwing a false positive. This was fixed by filtering out methods marked as private.

[1.14.4 Inheritance json after](https://gist.github.com/JDLogic/a4807622ed0b40ae16b7f410c45ce03e)