### PR TITLE
Update 1.14.4 patches

### DIFF
--- a/versions/1.14.4/patches/client/net/minecraft/client/util/SuffixArray.java.patch
+++ b/versions/1.14.4/patches/client/net/minecraft/client/util/SuffixArray.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/util/SuffixArray.java
++++ b/net/minecraft/client/util/SuffixArray.java
+@@ -55,7 +55,7 @@
+          }
+ 
+          public int compare(Integer p_compare_1_, Integer p_compare_2_) {
+-            return this.compare(p_compare_1_, p_compare_2_);
++            return this.compare((int)p_compare_1_, (int)p_compare_2_);
+          }
+       };
+       Swapper swapper = (p_194054_3_, p_194054_4_) -> {

--- a/versions/1.14.4/patches/client/net/minecraft/network/rcon/ClientThread.java.patch
+++ b/versions/1.14.4/patches/client/net/minecraft/network/rcon/ClientThread.java.patch
@@ -6,7 +6,7 @@
     public void run() {
 -      while(true) {
           try {
-+            while(true) { // Forge: #6265
++            while(true) {
              if (!this.field_72619_a) {
                 return;
              }

--- a/versions/1.14.4/patches/client/net/minecraft/network/rcon/ClientThread.java.patch
+++ b/versions/1.14.4/patches/client/net/minecraft/network/rcon/ClientThread.java.patch
@@ -1,0 +1,30 @@
+--- a/net/minecraft/network/rcon/ClientThread.java
++++ b/net/minecraft/network/rcon/ClientThread.java
+@@ -31,8 +31,8 @@
+    }
+ 
+    public void run() {
+-      while(true) {
+          try {
++            while(true) { // Forge: #6265
+             if (!this.field_72619_a) {
+                return;
+             }
+@@ -83,6 +83,7 @@
+                   continue;
+                }
+             }
++            }
+          } catch (SocketTimeoutException var17) {
+             return;
+          } catch (IOException var18) {
+@@ -94,9 +95,7 @@
+             this.func_72653_g();
+          }
+ 
+-         return;
+       }
+-   }
+ 
+    private void func_72654_a(int p_72654_1_, int p_72654_2_, String p_72654_3_) throws IOException {
+       ByteArrayOutputStream bytearrayoutputstream = new ByteArrayOutputStream(1248);

--- a/versions/1.14.4/patches/joined/net/minecraft/client/util/SuffixArray.java.patch
+++ b/versions/1.14.4/patches/joined/net/minecraft/client/util/SuffixArray.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/util/SuffixArray.java
++++ b/net/minecraft/client/util/SuffixArray.java
+@@ -58,7 +58,7 @@
+          }
+ 
+          public int compare(Integer p_compare_1_, Integer p_compare_2_) {
+-            return this.compare(p_compare_1_, p_compare_2_);
++            return this.compare((int)p_compare_1_, (int)p_compare_2_);
+          }
+       };
+       Swapper swapper = (p_194054_3_, p_194054_4_) -> {

--- a/versions/1.14.4/patches/joined/net/minecraft/network/rcon/ClientThread.java.patch
+++ b/versions/1.14.4/patches/joined/net/minecraft/network/rcon/ClientThread.java.patch
@@ -6,7 +6,7 @@
     public void run() {
 -      while(true) {
           try {
-+            while(true) { // Forge: #6265
++            while(true) {
              if (!this.field_72619_a) {
                 return;
              }

--- a/versions/1.14.4/patches/joined/net/minecraft/network/rcon/ClientThread.java.patch
+++ b/versions/1.14.4/patches/joined/net/minecraft/network/rcon/ClientThread.java.patch
@@ -1,0 +1,30 @@
+--- a/net/minecraft/network/rcon/ClientThread.java
++++ b/net/minecraft/network/rcon/ClientThread.java
+@@ -31,8 +31,8 @@
+    }
+ 
+    public void run() {
+-      while(true) {
+          try {
++            while(true) { // Forge: #6265
+             if (!this.field_72619_a) {
+                return;
+             }
+@@ -83,6 +83,7 @@
+                   continue;
+                }
+             }
++            }
+          } catch (SocketTimeoutException var17) {
+             return;
+          } catch (IOException var18) {
+@@ -94,9 +95,7 @@
+             this.func_72653_g();
+          }
+ 
+-         return;
+       }
+-   }
+ 
+    private void func_72654_a(int p_72654_1_, int p_72654_2_, String p_72654_3_) throws IOException {
+       ByteArrayOutputStream bytearrayoutputstream = new ByteArrayOutputStream(1248);

--- a/versions/1.14.4/patches/server/net/minecraft/network/rcon/ClientThread.java.patch
+++ b/versions/1.14.4/patches/server/net/minecraft/network/rcon/ClientThread.java.patch
@@ -6,7 +6,7 @@
     public void run() {
 -      while(true) {
           try {
-+            while(true) { // Forge: #6265
++            while(true) {
              if (!this.field_72619_a) {
                 return;
              }

--- a/versions/1.14.4/patches/server/net/minecraft/network/rcon/ClientThread.java.patch
+++ b/versions/1.14.4/patches/server/net/minecraft/network/rcon/ClientThread.java.patch
@@ -1,0 +1,30 @@
+--- a/net/minecraft/network/rcon/ClientThread.java
++++ b/net/minecraft/network/rcon/ClientThread.java
+@@ -31,8 +31,8 @@
+    }
+ 
+    public void run() {
+-      while(true) {
+          try {
++            while(true) { // Forge: #6265
+             if (!this.field_72619_a) {
+                return;
+             }
+@@ -83,6 +83,7 @@
+                   continue;
+                }
+             }
++            }
+          } catch (SocketTimeoutException var17) {
+             return;
+          } catch (IOException var18) {
+@@ -94,9 +95,7 @@
+             this.func_72653_g();
+          }
+ 
+-         return;
+       }
+-   }
+ 
+    private void func_72654_a(int p_72654_1_, int p_72654_2_, String p_72654_3_) throws IOException {
+       ByteArrayOutputStream bytearrayoutputstream = new ByteArrayOutputStream(1248);


### PR DESCRIPTION
- Add missing SuffixArray patch
- Add patch to fix loop in rcon/ClientThread

While looking at patches for 1.15, I noticed that the patch to SuffixArray was missing from 1.14.x. I figured I would incorporate the patch for rcon/ClientThread from MinecraftForge/MinecraftForge#6265 while I was at it. It's on my list of things to look at in FF.

Note: Both these patches are still needed in 1.15 as well.