### PR TITLE
Added option to test compiling decompiled MC with different java versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ eclipsej.bat
 /update/__pycache__/
 /update/bin/
 /update/output/
+/java_versions.json

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ ext {
     VERSIONS = subprojects.collect{it.name}.sort{a,b -> compareVersion(a, b)} as List
     NULL_OUPUT = new OutputStream() { public void write(int b){} }
     TIMESTAMP = (new Date()).format('yyyyMMdd.HHmmss')
+    COMPILERS_JSON = rootProject.file("java_versions.json").exists() ? new JsonSlurper().parseText(file(rootProject.file("java_versions.json")).text) : null
 }
 String.metaClass.rsplit = { chr -> [delegate.substring(0, delegate.lastIndexOf(chr)), delegate.substring(delegate.lastIndexOf(chr)+1)] }
 
@@ -682,6 +683,7 @@ subprojects {
     task mcinjectAll
     task fernflowerAll
     task fernflowerInject
+    task testRecompileAll
     task projectAll
     task projectDelete
     task projectReset
@@ -893,6 +895,41 @@ subprojects {
                         }
                     }
                     projectMakePatches.dependsOn "project${child.name}MakePatches"
+
+
+                    if (rootProject.ext.COMPILERS_JSON != null) {
+                        def json = rootProject.ext.COMPILERS_JSON
+                        task "testRecompile${child.name}"
+                        testRecompileAll.dependsOn("testRecompile${child.name}")
+                        json.each {
+                            def jvmName = it.key
+                            def jvmData = it.value
+                            task "clearTestRecompile${child.name}_${jvmName}"(type: Delete) {
+                                delete new File(dir, "build/testOutput_${child.name}_${jvmName}")
+                            }
+                            task "testRecompile${child.name}_${jvmName}"(type: JavaCompile) {
+                                dependsOn("project${child.name}ApplyPatches", "clearTestRecompile${child.name}_${jvmName}")
+                                options.fork = true
+                                options.compilerArgs.addAll(jvmData.extraCompilerArgs)
+                                options.forkOptions.with {
+                                    executable = jvmData.compilerExec
+                                    jvmArgs = jvmData.compilerJvmArgs
+                                }
+                                destinationDir = new File(dir, "build/testOutput_${child.name}_${jvmName}")
+                                source = new File(dir, "src/main/java")
+                                sourceCompatibility = '1.8'
+                                targetCompatibility = '1.8'
+                                // JavaCompile task type requires classpath to be specified before the task begins execution
+                                // but the data isn't generated yet, so instead - inject the classpath as the first thing done when it begins
+                                classpath = files()
+                                doFirst {
+                                    classpath = files(java.nio.file.Files.readAllLines(tasks.getByName("fernflowerLibraries${child.name}").dest.toPath())
+                                            .collect { file(it.substring(3)) }) // skip "-e="
+                                }
+                            }
+                            tasks["testRecompile${child.name}"].dependsOn("testRecompile${child.name}_${it.key}")
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION


As discussed on discord with lex.

When java_versions.json in root project directory exists, for each version with project${Side}ApplyPatches task, tasks with names testRecompile${sideName}_{jvmName} are added as dependncies of testRecompileAll task. I verfied that recompiling 1.15.2 with java 11 fails as expected.

Example contents of java_versions.json:
```
{
  "oraclejdk_10": {
    "compilerExec": "/opt/oracle_jdk10.0.2/bin/javac",
    "compilerJvmArgs": [],
    "extraCompilerArgs": []
  },
  "openjdk_11": {
    "compilerExec": "/opt/openjdk-bin-11.0.5_p10/bin/javac",
    "compilerJvmArgs": [],
    "extraCompilerArgs": []
  }
}
```
compilerJvmArgs are passed as jvmArgs option to fork options, and extraCompilerArgs are additional compiler parameters.

I also wanted to include running decompile with each java version (with javaExec option specified for each version in json) but that quickly turned into bigger changes to build.gradle than I first expected, so I'm separating that into separate PR that I will submit if/when it's done.

This technically still needs to be tested on windows, but I see no reason why it wouldn't work.
