### PR TITLE
Map 1.16 screen classes manually since bot is ded

### DIFF
--- a/versions/release/1.16.1/joined.tsrg
+++ b/versions/release/1.16.1/joined.tsrg
@@ -49220,15 +49220,15 @@ dhv com/mojang/realmsclient/RealmsMainScreen
 	at field_224009_Q
 	au field_224010_R
 	av field_224011_S
-	a (CI)Z func_231042_a_
+	a (CI)Z func_231042_a_ charTyped
 	a (CLdhu;)V func_237578_a_
 	a (DD)Z func_223979_a
-	a (DDI)Z func_231044_a_
-	a (III)Z func_231046_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (III)Z func_231046_a_ keyPressed
 	a (J)Ldip; func_223967_a
 	a (Labc;)V func_227932_a_
 	a (Ldhl;II)V func_237579_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IIIIZ)V func_237580_a_
 	a (Ldhl;IIIIZZ)V func_237581_a_
 	a (Ldhl;IIZIIZZ)V func_237582_a_
@@ -49254,7 +49254,7 @@ dhv com/mojang/realmsclient/RealmsMainScreen
 	a (Luh;)Z func_227931_a_
 	a (Z)Z func_237602_a_
 	a ([Lmr;)V func_237603_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldhl;)V func_237604_b_
 	b (Ldhl;II)V func_237605_b_
 	b (Ldhl;IIIII)V func_237606_b_
@@ -49276,7 +49276,7 @@ dhv com/mojang/realmsclient/RealmsMainScreen
 	c (Ldip;)Z func_223920_c
 	c (Ldni;)V func_237618_c_
 	c (Z)Z func_237619_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldhl;IIII)V func_237620_d_
 	d (Ldhv;)V func_237621_d_
 	d (Ldhv;Ldhl;IIII)V func_237622_d_
@@ -49284,7 +49284,7 @@ dhv com/mojang/realmsclient/RealmsMainScreen
 	d (Ldip;)Z func_223941_d
 	d (Ldni;)V func_237624_d_
 	d (Z)V func_237625_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldhl;IIII)V func_237626_e_
 	e (Ldhv;)Ldlx; func_237627_e_
 	e (Ldhv;Ldhl;IIII)V func_237628_e_
@@ -49401,7 +49401,7 @@ dhv$5 com/mojang/realmsclient/RealmsMainScreen$5
 dhv$a com/mojang/realmsclient/RealmsMainScreen$CloseButton
 	a field_223762_a
 	a (Ldhv;Ldni;)V func_237671_a_
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dhv$b com/mojang/realmsclient/RealmsMainScreen$ListEntry
 	a field_237672_a_
 dhv$c com/mojang/realmsclient/RealmsMainScreen$ServerState
@@ -49415,44 +49415,44 @@ dhv$c com/mojang/realmsclient/RealmsMainScreen$ServerState
 dhv$d com/mojang/realmsclient/RealmsMainScreen$NewsButton
 	a field_223763_a
 	a (Ldhv;Ldni;)V func_237673_a_
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dhv$e com/mojang/realmsclient/RealmsMainScreen$PendingInvitesButton
 	a field_223764_a
 	a (Ldhv;Ldni;)V func_237674_a_
-	b (Ldhl;IIF)V func_230431_b_
-	d ()V func_231023_e_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
+	d ()V func_231023_e_ tick
 dhv$f com/mojang/realmsclient/RealmsMainScreen$ServerList
 	a field_223865_a
 	o field_241824_o_
 	a ()V func_231409_q_
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)V func_231400_a_
 	a (IIDDI)V func_231401_a_
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Ldhv$b;)I func_241825_a_
-	a (Ldne$a;)V func_241215_a_
-	b ()Z func_230971_aw__
-	b (Ldhv$b;)V func_241215_a_
-	c ()I func_230945_b_
-	d ()I func_230949_c_
+	a (Ldne$a;)V func_241215_a_ setSelected
+	b ()Z func_230971_aw__ isFocused
+	b (Ldhv$b;)V func_241215_a_ setSelected
+	c ()I func_230945_b_ getMaxPosition
+	d ()I func_230949_c_ getRowWidth
 dhv$g com/mojang/realmsclient/RealmsMainScreen$ServerEntry
 	b field_223735_b
 	c field_223734_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (Ldhl;II)V func_237676_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhv$g;)Ldip; func_237677_a_
 	a (Ldip;Ldhl;IIII)V func_237678_a_
 	b (Ldip;Ldhl;IIII)V func_237679_b_
 dhv$h com/mojang/realmsclient/RealmsMainScreen$InfoButton
 	a field_223765_a
 	a (Ldhv;Ldni;)V func_237680_a_
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dhv$i com/mojang/realmsclient/RealmsMainScreen$TrialServerEntry
 	b field_223737_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (Ldhl;IIIII)V func_237681_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 dhw net/minecraft/client/util/UploadSpeed
 	a B
 	b KB
@@ -50036,8 +50036,8 @@ djl com/mojang/realmsclient/gui/RealmsServerSlotButton
 	a (Ldhl;IIIIZLjava/lang/String;IJLjava/lang/String;ZZLdjl$a;Lmr;)V func_237718_a_
 	a (Ldip;Ljava/lang/String;ZZLdjl$a;)Lcom/mojang/datafixers/util/Pair; func_237719_a_
 	a (Ldip;ZZ)Ldjl$a; func_237720_a_
-	b (Ldhl;IIF)V func_230431_b_
-	d ()V func_231023_e_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
+	d ()V func_231023_e_ tick
 djl$a com/mojang/realmsclient/gui/RealmsServerSlotButton$Action
 	a NOTHING
 	b SWITCH_SLOT
@@ -50075,18 +50075,18 @@ djn com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen
 	a field_224047_c
 	b field_224049_e
 	c field_224051_g
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldjn;)Ldlx; func_237729_a_
 	a (Ldjn;Ljava/lang/String;Ljava/lang/String;)Lmr; func_237730_a_
 	a (Ldni;)V func_237731_a_
 	a (Ljava/lang/String;)Lmr; func_237732_a_
 	a (Ljava/lang/String;Ljava/lang/String;)Lmr; func_237733_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldjn;)Ldif; func_237734_b_
 	b (Ljava/lang/String;)Lmr; func_237735_b_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 djn$a com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen$BackupInfoList
 	a field_223864_a
 	a (Ljava/lang/String;Ljava/lang/String;)V func_237736_a_
@@ -50094,7 +50094,7 @@ djn$b com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen$BackupInfoEntry
 	a field_237737_a_
 	b field_237738_b_
 	c field_237739_c_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 djo com/mojang/realmsclient/gui/screens/RealmsBackupScreen
 	a field_224114_a
 	b field_237740_b_
@@ -50114,8 +50114,8 @@ djo com/mojang/realmsclient/gui/screens/RealmsBackupScreen
 	B field_224127_n
 	a ()Lorg/apache/logging/log4j/Logger; func_237742_a_
 	a (I)I func_237743_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Ljava/lang/String;II)V func_237744_a_
 	a (Ldif;Ljava/lang/String;)V func_224103_a
 	a (Ldjo;)Ldip; func_224099_a
@@ -50124,7 +50124,7 @@ djo com/mojang/realmsclient/gui/screens/RealmsBackupScreen
 	a (Ldjo;Ljava/lang/String;)Ljava/lang/String; func_237746_a_
 	a (Ldjo;Ljava/util/List;)Ljava/util/List; func_237747_a_
 	a (Ldni;)V func_237748_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)V func_224104_b
 	b (Ldjo;)Ldlx; func_237750_b_
 	b (Ldjo;I)V func_237751_b_
@@ -50156,23 +50156,23 @@ djo$1 com/mojang/realmsclient/gui/screens/RealmsBackupScreen$1
 	run ()V run
 djo$a com/mojang/realmsclient/gui/screens/RealmsBackupScreen$BackupObjectSelectionList
 	a field_223868_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)V func_231400_a_
 	a (IIDDI)V func_231401_a_
-	a (Ldhl;)V func_230433_a_
+	a (Ldhl;)V func_230433_a_ renderBackground
 	a (Ldif;)V func_223867_a
-	a (Ldjo$b;)V func_241215_a_
-	a (Ldne$a;)V func_241215_a_
-	b ()Z func_230971_aw__
+	a (Ldjo$b;)V func_241215_a_ setSelected
+	a (Ldne$a;)V func_241215_a_ setSelected
+	b ()Z func_230971_aw__ isFocused
 	b (I)V func_223866_a
-	c ()I func_230945_b_
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	c ()I func_230945_b_ getMaxPosition
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 djo$b com/mojang/realmsclient/gui/screens/RealmsBackupScreen$BackupObjectSelectionListEntry
 	a field_223743_b
 	b field_237765_b_
 	a (Ldhl;IIII)V func_237766_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;Ldif;IIII)V func_237767_a_
 	a (Ljava/util/Date;)Ljava/lang/String; func_223738_a
 	b (Ldhl;IIII)V func_237768_b_
@@ -50190,21 +50190,21 @@ djp com/mojang/realmsclient/gui/screens/RealmsBrokenWorldScreen
 	w field_224087_q
 	a ()V func_237772_a_
 	a (I)I func_224065_a
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (ILdni;)V func_237773_a_
 	a (IZ)V func_237774_a_
 	a (J)V func_224068_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IIIIZLjava/lang/String;IJLjava/lang/String;Z)V func_237775_a_
 	a (Ldni;)V func_237776_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)V func_224066_b
 	b (ILdni;)V func_237777_b_
 	b (IZ)V func_237778_b_
 	b (J)V func_237779_b_
 	c (ILdni;)V func_237780_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()V func_224058_a
 	k ()V func_224060_e
 	l ()Z func_224069_f
@@ -50216,10 +50216,10 @@ djp com/mojang/realmsclient/gui/screens/RealmsBrokenWorldScreen
 djq com/mojang/realmsclient/gui/screens/RealmsClientOutdatedScreen
 	a field_224129_a
 	b field_224130_b
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237786_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 djr com/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen
 	a field_224413_a
 	b field_237787_b_
@@ -50244,11 +50244,11 @@ djr com/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen
 	G field_224431_s
 	a ()V func_224398_a
 	a (I)V func_224402_a
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (ILdip;)V func_224403_a
 	a (ILdni;)V func_237795_a_
 	a (J)V func_224387_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Lmr;II)V func_237796_a_
 	a (Ldip;)V func_224385_a
 	a (Ldip;IZ)V func_237797_a_
@@ -50260,7 +50260,7 @@ djr com/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen
 	a (Ljava/lang/String;Ljava/lang/String;)V func_224410_a
 	a (Lmr;)V func_237801_a_
 	a (ZLdqs;)V func_237802_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)I func_224411_b
 	b (II)I func_224374_a
 	b (ILdip;)V func_224388_b
@@ -50272,10 +50272,10 @@ djr com/mojang/realmsclient/gui/screens/RealmsConfigureWorldScreen
 	c (I)I func_224368_c
 	c (Ldhl;IIII)V func_237807_c_
 	c (Ldni;)V func_237808_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldhl;IIII)V func_237809_d_
 	d (Ldni;)V func_237810_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldhl;IIII)V func_237811_e_
 	e (Ldni;)V func_237812_e_
 	f (Ldhl;IIII)V func_237813_f_
@@ -50303,11 +50303,11 @@ djs com/mojang/realmsclient/gui/screens/RealmsConfirmScreen
 	b field_224142_b
 	c field_224146_f
 	p field_224147_g
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237825_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_237826_b_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 djt com/mojang/realmsclient/gui/screens/RealmsCreateRealmScreen
 	a field_224135_a
 	b field_224136_b
@@ -50315,14 +50315,14 @@ djt com/mojang/realmsclient/gui/screens/RealmsCreateRealmScreen
 	p field_224138_d
 	q field_224139_e
 	r field_224140_f
-	a (CI)Z func_231042_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237827_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_237828_b_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()V func_224132_a
 	k ()Z func_224133_b
 	l ()V func_237829_l_
@@ -50352,16 +50352,16 @@ dju com/mojang/realmsclient/gui/screens/RealmsDownloadLatestWorldScreen
 	H field_224195_u
 	I field_224198_x
 	J field_237831_J_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;J)V func_237833_a_
 	a (Ldni;)V func_237834_a_
 	a (Ljava/lang/String;)J func_224152_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldhl;)V func_237835_b_
 	c (Ldhl;)V func_237836_c_
 	c (Z)V func_237837_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldhl;)V func_237838_d_
 	i ()V func_224162_c
 	k ()V func_224174_d
@@ -50376,12 +50376,12 @@ djv com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen
 	a field_224228_a
 	b field_224229_b
 	c field_224230_c
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldjh;)V func_224224_a
 	a (Ldni;)V func_237840_a_
 	a (Lmr;)V func_237841_a_
 	a (Lmr;Lmr;)V func_237842_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 djw com/mojang/realmsclient/gui/screens/RealmsInviteScreen
 	a field_224213_a
 	b field_224214_b
@@ -50390,14 +50390,14 @@ djw com/mojang/realmsclient/gui/screens/RealmsInviteScreen
 	q field_224217_e
 	r field_224222_j
 	s field_224223_k
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237843_a_
 	a (Ljava/lang/String;)V func_224209_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_237844_b_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()V func_224211_a
 djx com/mojang/realmsclient/gui/screens/RealmsLongConfirmationScreen
 	a field_237845_a_
@@ -50405,10 +50405,10 @@ djx com/mojang/realmsclient/gui/screens/RealmsLongConfirmationScreen
 	c field_224255_f
 	p field_224256_g
 	q field_224258_i
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237846_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_237847_b_
 	c (Ldni;)V func_237848_c_
 djx$a com/mojang/realmsclient/gui/screens/RealmsLongConfirmationScreen$Type
@@ -50431,15 +50431,15 @@ djy com/mojang/realmsclient/gui/screens/RealmsLongRunningMcoTaskScreen
 	u field_224248_l
 	v field_224249_m
 	a ()V func_237850_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237851_a_
 	a (Lmr;)V func_230434_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_237852_b_
 	b (Ljava/lang/String;)V func_224234_b
 	c ()Z func_224235_b
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	i ()V func_224236_c
 djz com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen
 	a field_237853_a_
@@ -50452,12 +50452,12 @@ djz com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen
 	t field_224269_e
 	u field_224270_f
 	a (Ldhl;II)V func_237857_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Z)Z func_224264_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Z)Z func_224263_b
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()Z func_237858_g_
 	k ()Z func_237859_j_
 	l ()V func_224261_a
@@ -50466,9 +50466,9 @@ djz$1 com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen$1
 	run ()V run
 dka com/mojang/realmsclient/gui/screens/RealmsParentalConsentScreen
 	a field_224260_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237860_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_237861_b_
 	c (Ldni;)V func_237862_c_
 dkb com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen
@@ -50485,15 +50485,15 @@ dkb com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen
 	w field_224341_i
 	a ()Lorg/apache/logging/log4j/Logger; func_237865_a_
 	a (I)V func_224318_a
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Ljava/lang/String;II)V func_237866_a_
 	a (Ldkb;)Ldlx; func_237867_a_
 	a (Ldkb;I)V func_237868_a_
 	a (Ldkb;Ljava/lang/String;)Ljava/lang/String; func_237869_a_
 	a (Ldkb;Z)Z func_237870_a_
 	a (Ldni;)V func_237871_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)V func_224321_b
 	b (Ldkb;)Ldkb$b; func_237873_b_
 	b (Ldkb;I)I func_237874_b_
@@ -50533,9 +50533,9 @@ dkb$a com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$InvitationE
 	a field_223751_b
 	b field_223750_a
 	c field_223752_c
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (Ldhl;II)V func_237892_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;Ldij;IIII)V func_237893_a_
 	a (Ldkb$a;)Ldij; func_237894_a_
 dkb$a$a com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$InvitationEntry$AcceptButton
@@ -50549,14 +50549,14 @@ dkb$a$b com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Invitatio
 dkb$b com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$InvitationList
 	a field_223874_a
 	a (I)V func_231400_a_
-	a (Ldhl;)V func_230433_a_
-	a (Ldkb$a;)V func_241215_a_
-	a (Ldne$a;)V func_241215_a_
-	b ()Z func_230971_aw__
+	a (Ldhl;)V func_230433_a_ renderBackground
+	a (Ldkb$a;)V func_241215_a_ setSelected
+	a (Ldne$a;)V func_241215_a_ setSelected
+	b ()Z func_230971_aw__ isFocused
 	b (I)V func_223872_a
-	c ()I func_230945_b_
+	c ()I func_230945_b_ getMaxPosition
 	c (I)V func_223873_b
-	d ()I func_230949_c_
+	d ()I func_230949_c_ getRowWidth
 dkc com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
 	a field_224300_a
 	b field_237895_b_
@@ -50578,15 +50578,15 @@ dkc com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
 	D field_224313_n
 	E field_224314_o
 	a (I)I func_237902_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Ljava/lang/String;II)V func_237903_a_
 	a (Ldii;)V func_224283_a
 	a (Ldkc;)I func_237904_a_
 	a (Ldkc;I)V func_237905_a_
 	a (Ldkc;Ldhl;IIII)V func_237906_a_
 	a (Ldni;)V func_237907_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)I func_237908_b_
 	b (Ldkc;)I func_237909_b_
 	b (Ldkc;I)V func_237910_b_
@@ -50604,7 +50604,7 @@ dkc com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
 	d (Ldkc;)Ljava/lang/String; func_237922_d_
 	d (Ldkc;I)I func_237923_d_
 	d (Ldni;)V func_237924_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldhl;IIII)V func_237925_e_
 	e (Ldkc;)V func_237926_e_
 	f (Ldkc;)Ldmt; func_237927_f_
@@ -50621,22 +50621,22 @@ dkc$a com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$InvitedEntry
 	a field_223747_b
 	b field_237930_b_
 	a (Ldhl;I)V func_237931_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;Ldim;IIII)V func_237932_a_
 dkc$b com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$InvitedList
 	a field_223871_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)V func_231400_a_
 	a (IIDDI)V func_231401_a_
-	a (Ldhl;)V func_230433_a_
+	a (Ldhl;)V func_230433_a_ renderBackground
 	a (Ldim;)V func_223870_a
-	a (Ldkc$a;)V func_241215_a_
-	a (Ldne$a;)V func_241215_a_
-	b ()Z func_230971_aw__
+	a (Ldkc$a;)V func_241215_a_ setSelected
+	a (Ldne$a;)V func_241215_a_ setSelected
+	b ()Z func_230971_aw__ isFocused
 	b (I)V func_223869_a
-	c ()I func_230945_b_
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	c ()I func_230945_b_ getMaxPosition
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 dkd com/mojang/realmsclient/gui/screens/RealmsResetNormalWorldScreen
 	a field_224354_b
 	b field_224355_c
@@ -50645,15 +50645,15 @@ dkd com/mojang/realmsclient/gui/screens/RealmsResetNormalWorldScreen
 	q field_224358_f
 	r field_224353_a
 	s field_224365_m
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_237933_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_237934_b_
 	c (Ldni;)V func_237935_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_237936_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	i ()Lmr; func_237937_g_
 	k ()Lmr; func_237938_j_
 dke com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen
@@ -50686,8 +50686,8 @@ dke com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen
 	M field_237943_M_
 	a ()Lorg/apache/logging/log4j/Logger; func_224436_a
 	a (I)V func_224445_b
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IILmr;Luh;ZZ)V func_237948_a_
 	a (Ldjd;)V func_223627_a_
 	a (Ldke$c;)V func_224438_a
@@ -50698,7 +50698,7 @@ dke com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen
 	a (Ljava/lang/Runnable;)V func_237952_a_
 	a (Ljava/lang/String;)V func_224432_a
 	a (Ljava/lang/String;Ldjd;IZ)V func_237953_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)I func_224434_c
 	b (Ldjd;)V func_224435_b
 	b (Ldke$c;)V func_224437_b
@@ -50708,7 +50708,7 @@ dke com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen
 	c (Ldni;)V func_237955_c_
 	d (Ldke;Ldje;)Ldje; func_224442_d
 	d (Ldni;)V func_237956_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_237957_e_
 	f (Ldni;)V func_237958_f_
 	g (Ldni;)V func_237959_g_
@@ -50724,7 +50724,7 @@ dke$2 com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen$2
 dke$a com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen$TexturedButton
 	a field_223823_b
 	b field_223824_c
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dke$b com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen$ResetType
 	a NONE
 	b GENERATE
@@ -50762,14 +50762,14 @@ dkg com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen
 	z field_224561_o
 	A field_237967_A_
 	a (I)I func_237968_a_
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Ldaf;)Ljava/lang/String; func_237969_a_
 	a (Ldaf;Ldaf;)I func_237970_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldkg;)Ljava/util/List; func_237971_a_
 	a (Ldkg;I)I func_237972_a_
 	a (Ldni;)V func_237973_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldaf;)Ljava/lang/String; func_237974_b_
 	b (Ldkg;)Ldni; func_237975_b_
 	b (Ldni;)V func_237976_b_
@@ -50777,7 +50777,7 @@ dkg com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen
 	c (Ldkg;)I func_237978_c_
 	d (Ldaf;)Ljava/lang/String; func_237979_d_
 	d (Ldkg;)Ldkg$b; func_237980_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldkg;)Ljava/lang/String; func_237981_e_
 	f (Ldkg;)Ljava/lang/String; func_224546_g
 	g (Ldkg;)Ldmt; func_237982_g_
@@ -50788,18 +50788,18 @@ dkg com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen
 dkg$a com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$WorldSelectionEntry
 	a field_223760_b
 	b field_223759_a
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;Ldaf;III)V func_237985_a_
 dkg$b com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$WorldSelectionList
 	a field_223882_a
 	a (I)V func_231400_a_
 	a (Ldaf;)V func_237986_a_
-	a (Ldhl;)V func_230433_a_
-	a (Ldkg$a;)V func_241215_a_
-	a (Ldne$a;)V func_241215_a_
-	b ()Z func_230971_aw__
-	c ()I func_230945_b_
+	a (Ldhl;)V func_230433_a_ renderBackground
+	a (Ldkg$a;)V func_241215_a_ setSelected
+	a (Ldne$a;)V func_241215_a_ setSelected
+	b ()Z func_230971_aw__ isFocused
+	c ()I func_230945_b_ getMaxPosition
 dkh com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen
 	a field_224515_a
 	b field_237987_b_
@@ -50822,10 +50822,10 @@ dkh com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen
 	E field_224530_p
 	F field_224531_q
 	a ()Lorg/apache/logging/log4j/Logger; func_237990_a_
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)I func_237991_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IILjava/util/List;)V func_237992_a_
 	a (Ldhl;Ljava/lang/String;II)V func_237993_a_
 	a (Ldje;)V func_224497_a
@@ -50839,7 +50839,7 @@ dkh com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen
 	a (Ldni;)V func_238000_a_
 	a (Lmr;)V func_238001_a_
 	a ([Lmr;)V func_238002_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldkh;)Ldkh$b; func_238004_b_
 	b (Ldkh;I)I func_224508_a
 	b (Ldkh;Ljava/lang/String;)Ljava/lang/String; func_238005_b_
@@ -50847,7 +50847,7 @@ dkh com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen
 	c ()Luh; func_238003_b_
 	c (Ldkh;)Z func_238007_c_
 	c (Ldni;)V func_238008_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldkh;)Ljava/lang/String; func_238010_d_
 	d (Ldni;)V func_238011_d_
 	e (Ldkh;)I func_238012_e_
@@ -50882,24 +50882,24 @@ dkh$1 com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$1
 dkh$a com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$WorldTemplateSelectionEntry
 	a field_223757_b
 	b field_223756_a
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;IIIILdjd;)V func_238027_a_
 	a (Ldhl;IIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V func_238028_a_
 	a (Ldhl;Ldjd;IIII)V func_238029_a_
 	a (Ldkh$a;)Ldjd; func_238030_a_
 dkh$b com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$WorldTemplateSelectionList
 	a field_223880_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)V func_231400_a_
-	a (Ldhl;)V func_230433_a_
+	a (Ldhl;)V func_230433_a_ renderBackground
 	a (Ldjd;)V func_223876_a
-	a (Ldkh$a;)V func_241215_a_
-	a (Ldne$a;)V func_241215_a_
-	b ()Z func_230971_aw__
+	a (Ldkh$a;)V func_241215_a_ setSelected
+	a (Ldne$a;)V func_241215_a_ setSelected
+	b ()Z func_230971_aw__ isFocused
 	b (I)Ldjd; func_223877_a
 	b (Ldkh$a;)Ldjd; func_223875_a
-	c ()I func_230945_b_
-	d ()I func_230949_c_
+	c ()I func_230945_b_ getMaxPosition
+	d ()I func_230949_c_ getRowWidth
 	f ()Z func_223878_a
 	g ()Ljava/util/List; func_223879_b
 dki com/mojang/realmsclient/gui/screens/RealmsSettingsScreen
@@ -50910,15 +50910,15 @@ dki com/mojang/realmsclient/gui/screens/RealmsSettingsScreen
 	q field_224570_f
 	r field_224571_g
 	a ()V func_224563_a
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_238031_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_238032_b_
 	c (Ldni;)V func_238033_c_
 	c (Z)V func_238034_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 dkj com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen
 	a field_238035_a_
 	b field_238036_b_
@@ -50950,19 +50950,19 @@ dkj com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen
 	N field_224635_A
 	O field_224636_B
 	P field_224637_C
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldkj;)Ldkj$a; func_238044_a_
 	a (Ldkj;Ljava/lang/Integer;)Ljava/lang/Integer; func_238045_a_
 	a (Ldni;)V func_238046_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldkj;)Ljava/lang/Integer; func_238047_b_
 	b (Ldni;)V func_238048_b_
 	c (Ldni;)V func_238049_c_
 	c (Z)Lmr; func_238050_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_238051_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_238052_e_
 	f (Ldni;)V func_238053_f_
 	g (Ldni;)V func_238055_g_
@@ -50984,9 +50984,9 @@ dkj$a com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen$SettingsSlider
 	c field_238066_c_
 	d field_238067_d_
 	a ()V func_230972_a_
-	a (DD)V func_230982_a_
+	a (DD)V func_230982_a_ onClick
 	b ()V func_230979_b_
-	a_ (DD)V func_231000_a__
+	a_ (DD)V func_231000_a__ onRelease
 dkk com/mojang/realmsclient/gui/screens/RealmsSubscriptionInfoScreen
 	a field_224579_a
 	b field_224580_b
@@ -51001,12 +51001,12 @@ dkk com/mojang/realmsclient/gui/screens/RealmsSubscriptionInfoScreen
 	w field_224592_n
 	a ()Lorg/apache/logging/log4j/Logger; func_238068_a_
 	a (I)Ljava/lang/String; func_224576_a
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (J)V func_224573_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldkk;)Ldip; func_224575_a
 	a (Ldni;)V func_238069_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (J)Ljava/lang/String; func_224574_b
 	b (Ldkk;)Ldlx; func_238070_b_
 	b (Ldni;)V func_238071_b_
@@ -51014,7 +51014,7 @@ dkk com/mojang/realmsclient/gui/screens/RealmsSubscriptionInfoScreen
 	c (Ldni;)V func_238073_c_
 	c (Z)V func_238074_c_
 	d (Ldkk;)Ldlx; func_238075_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 dkk$1 com/mojang/realmsclient/gui/screens/RealmsSubscriptionInfoScreen$1
 	a field_223846_a
 	a ()V func_238076_a_
@@ -51026,13 +51026,13 @@ dkl com/mojang/realmsclient/gui/screens/RealmsTermsScreen
 	p field_224725_d
 	q field_224727_f
 	r field_224728_g
-	a (DDI)Z func_231044_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_238077_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_238078_b_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	i ()V func_224721_a
 dkm com/mojang/realmsclient/gui/screens/RealmsUploadScreen
 	a field_224696_a
@@ -51058,22 +51058,22 @@ dkm com/mojang/realmsclient/gui/screens/RealmsUploadScreen
 	G field_224716_u
 	H field_224717_v
 	I field_238080_I_
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (JLdkn;)V func_238082_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;J)V func_238083_a_
 	a (Ldni;)V func_238084_a_
 	a (Ljava/io/File;)Z func_224692_a
 	a (Lorg/apache/commons/compress/archivers/tar/TarArchiveOutputStream;Ljava/lang/String;Ljava/lang/String;Z)V func_224669_a
 	a ([Lmr;)V func_238085_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldhl;)V func_238086_b_
 	b (Ldni;)V func_238087_b_
 	b (Ljava/io/File;)Ljava/io/File; func_224675_b
 	c (Ldhl;)V func_238088_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldhl;)V func_238089_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	i ()V func_224679_c
 	k ()V func_224695_d
 	l ()V func_224682_h
@@ -52524,30 +52524,30 @@ dmu net/minecraft/client/gui/IngameGui
 	l ()Laoy; func_212305_n
 	m ()V func_194808_p
 dmv net/minecraft/client/gui/AbstractGui
-	a field_230662_a_
-	f field_230663_f_
-	g field_230664_g_
-	h field_230665_h_
+	a field_230662_a_ blitOffset
+	f field_230663_f_ BACKGROUND_LOCATION
+	g field_230664_g_ STATS_ICON_LOCATION
+	h field_230665_h_ GUI_ICONS_LOCATION
 	a (IILjava/util/function/BiConsumer;)V func_238459_a_
-	a (Lb;IIIII)V func_238460_a_
-	a (Lb;IIIIIFFFF)V func_238461_a_
-	a (Lb;Ldhg;IIIIIII)V func_238462_a_
-	a (Ldhl;IIFFIIII)V func_238463_a_
-	a (Ldhl;IIIFFIIII)V func_238464_a_
-	a (Ldhl;IIII)V func_238465_a_
-	a (Ldhl;IIIIFFIIII)V func_238466_a_
-	a (Ldhl;IIIII)V func_238467_a_
-	a (Ldhl;IIIIII)V func_238468_a_
-	a (Ldhl;IIIIIIIFFII)V func_238469_a_
-	a (Ldhl;IIIIILelv;)V func_238470_a_
-	a (Ldhl;Ldmt;Ljava/lang/String;III)V func_238471_a_
-	a (Ldhl;Ldmt;Lmu;III)V func_238472_a_
-	b (Ldhl;IIII)V func_238473_b_
-	b (Ldhl;IIIIII)V func_238474_b_
-	b (Ldhl;Ldmt;Lmu;III)V func_238475_b_
-	c (Ldhl;Ldmt;Ljava/lang/String;III)V func_238476_c_
-	e (I)V func_230926_e_
-	o ()I func_230927_p_
+	a (Lb;IIIII)V func_238460_a_ fill
+	a (Lb;IIIIIFFFF)V func_238461_a_ innerBlit
+	a (Lb;Ldhg;IIIIIII)V func_238462_a_ fillGradient
+	a (Ldhl;IIFFIIII)V func_238463_a_ blit
+	a (Ldhl;IIIFFIIII)V func_238464_a_ blit
+	a (Ldhl;IIII)V func_238465_a_ hLine
+	a (Ldhl;IIIIFFIIII)V func_238466_a_ blit
+	a (Ldhl;IIIII)V func_238467_a_ fill
+	a (Ldhl;IIIIII)V func_238468_a_ fillGradient
+	a (Ldhl;IIIIIIIFFII)V func_238469_a_ innerBlit
+	a (Ldhl;IIIIILelv;)V func_238470_a_ blit
+	a (Ldhl;Ldmt;Ljava/lang/String;III)V func_238471_a_ drawCenteredString
+	a (Ldhl;Ldmt;Lmu;III)V func_238472_a_ drawCenteredString
+	b (Ldhl;IIII)V func_238473_b_ vLine
+	b (Ldhl;IIIIII)V func_238474_b_ blit
+	b (Ldhl;Ldmt;Lmu;III)V func_238475_b_ drawString
+	c (Ldhl;Ldmt;Ljava/lang/String;III)V func_238476_c_ drawString
+	e (I)V func_230926_e_ setBlitOffset
+	o ()I func_230927_p_ getBlitOffset
 dmw net/minecraft/client/gui/MapItemRenderer
 	a field_148253_a
 	b field_228085_d_
@@ -52596,85 +52596,85 @@ dna net/minecraft/client/gui/chat/NormalChatListener
 	a field_192581_a
 	a (Lmo;Lmr;Ljava/util/UUID;)V func_192576_a
 dnc net/minecraft/client/gui/widget/button/AbstractButton
-	a (DD)V func_230982_a_
-	a (III)Z func_231046_a_
-	b ()V func_230930_b_
+	a (DD)V func_230982_a_ onClick
+	a (III)Z func_231046_a_ keyPressed
+	b ()V func_230930_b_ onPress
 dnd net/minecraft/client/gui/widget/GameSettingsSlider
 	a field_238477_a_
 dne net/minecraft/client/gui/widget/list/AbstractList
-	a field_230667_a_
-	b field_230668_b_
-	c field_230669_c_
-	d field_230670_d_
-	e field_230671_e_
-	i field_230672_i_
-	j field_230673_j_
-	k field_230674_k_
-	l field_230675_l_
-	m field_230676_m_
-	n field_230677_n_
-	o field_230678_o_
-	p field_230679_p_
-	q field_230680_q_
-	r field_230681_r_
-	s field_230682_s_
-	a (D)V func_230932_a_
-	a (DD)Ldne$a; func_230933_a_
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
-	a (I)V func_230937_a_
-	a (II)V func_230938_a_
-	a (III)Z func_231046_a_
-	a (IIII)V func_230940_a_
-	a (Ldhl;)V func_230433_a_
-	a (Ldhl;II)V func_230447_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldhl;IIIIF)V func_238478_a_
-	a (Ldhl;IILdhn;)V func_230448_a_
-	a (Ldne$a;)V func_241215_a_
-	a (Ldne$b;)V func_241219_a_
+	a field_230667_a_ children
+	b field_230668_b_ minecraft
+	c field_230669_c_ itemHeight
+	d field_230670_d_ width
+	e field_230671_e_ height
+	i field_230672_i_ y0
+	j field_230673_j_ y1
+	k field_230674_k_ x1
+	l field_230675_l_ x0
+	m field_230676_m_ centerListVertically
+	n field_230677_n_ headerHeight
+	o field_230678_o_ scrollAmount
+	p field_230679_p_ renderSelection
+	q field_230680_q_ renderHeader
+	r field_230681_r_ scrolling
+	s field_230682_s_ selected
+	a (D)V func_230932_a_ setScrollAmount
+	a (DD)Ldne$a; func_230933_a_ getEntryAtPosition
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
+	a (I)V func_230937_a_ scroll
+	a (II)V func_230938_a_ clickedHeader
+	a (III)Z func_231046_a_ keyPressed
+	a (IIII)V func_230940_a_ updateSize
+	a (Ldhl;)V func_230433_a_ renderBackground
+	a (Ldhl;II)V func_230447_a_ renderDecorations
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldhl;IIIIF)V func_238478_a_ renderList
+	a (Ldhl;IILdhn;)V func_230448_a_ renderHeader
+	a (Ldne$a;)V func_241215_a_ setSelected
+	a (Ldne$b;)V func_241219_a_ moveSelection
 	a (Ldne$b;Ljava/util/function/Predicate;)V func_241572_a_
 	a (Ldne;Ldne$a;)V func_238479_a_
-	a (Ljava/util/Collection;)V func_230942_a_
-	a (Z)V func_230943_a_
-	a (ZI)V func_230944_a_
-	b ()Z func_230971_aw__
-	b (DD)Z func_231047_b_
-	b (DDI)V func_230947_b_
-	b (I)I func_230948_b_
-	b (Ldne$a;)I func_230513_b_
-	c ()I func_230945_b_
-	c (DDI)Z func_231048_c_
-	c (Ldne$a;)V func_230951_c_
-	d ()I func_230949_c_
-	d (I)Ldne$a; func_230953_d_
-	d (Ldne$a;)V func_230954_d_
-	e ()I func_230952_d_
-	e (Ldne$a;)Z func_230956_e_
-	f ()I func_230955_e_
-	f (I)Z func_230957_f_
+	a (Ljava/util/Collection;)V func_230942_a_ replaceEntries
+	a (Z)V func_230943_a_ setRenderSelection
+	a (ZI)V func_230944_a_ setRenderHeader
+	b ()Z func_230971_aw__ isFocused
+	b (DD)Z func_231047_b_ isMouseOver
+	b (DDI)V func_230947_b_ updateScrollingState
+	b (I)I func_230948_b_ getRowBottom
+	b (Ldne$a;)I func_230513_b_ addEntry
+	c ()I func_230945_b_ getMaxPosition
+	c (DDI)Z func_231048_c_ mouseReleased
+	c (Ldne$a;)V func_230951_c_ centerScrollOn
+	d ()I func_230949_c_ getRowWidth
+	d (I)Ldne$a; func_230953_d_ getEntry
+	d (Ldne$a;)V func_230954_d_ ensureVisible
+	e ()I func_230952_d_ getScrollbarPosition
+	e (Ldne$a;)Z func_230956_e_ removeEntry
+	f ()I func_230955_e_ getMaxScroll
+	f (I)Z func_230957_f_ isSelectedItem
 	f (Ldne$a;)V func_238480_f_
-	g (I)V func_230959_g_
+	g (I)V func_230959_g_ setLeftPos
 	g (Ldne$a;)Z func_241573_g_
-	h ()Ldne$a; func_230958_g_
-	h (I)I func_230962_i_
-	i ()Ldne$a; func_241217_q_
-	i (I)Ldne$a; func_230964_j_
-	k ()V func_230963_j_
-	l ()I func_230965_k_
-	m ()D func_230966_l_
+	h ()Ldne$a; func_230958_g_ getSelected
+	h (I)I func_230962_i_ getRowTop
+	i ()Ldne$a; func_241217_q_ getFocused
+	i (I)Ldne$a; func_230964_j_ remove
+	k ()V func_230963_j_ clearEntries
+	l ()I func_230965_k_ getItemCount
+	m ()D func_230966_l_ getScrollAmount
 	n ()I func_230967_m_
 	p ()V func_241574_n_
-	q ()I func_230968_n_
-	r ()Ldof; func_241217_q_
-	av_ ()Ljava/util/List; func_231039_at__
+	q ()I func_230968_n_ getRowLeft
+	r ()Ldof; func_241217_q_ getFocused
+	av_ ()Ljava/util/List; func_231039_at__ children
 dne$1 net/minecraft/client/gui/widget/list/AbstractList$1
 dne$a net/minecraft/client/gui/widget/list/AbstractList$AbstractListEntry
-	a field_230666_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a field_230666_a_ list
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldne$a;Ldne;)Ldne; func_238481_a_
-	b (DD)Z func_231047_b_
+	b (DD)Z func_231047_b_ isMouseOver
 dne$b net/minecraft/client/gui/widget/list/AbstractList$Ordering
 	a UP
 	b DOWN
@@ -52697,59 +52697,59 @@ dnf net/minecraft/client/gui/widget/AbstractSlider
 	b field_230683_b_
 	a ()V func_230972_a_
 	a (D)V func_230973_a_
-	a (DD)V func_230982_a_
-	a (DDDD)V func_230983_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;Ldlx;II)V func_230441_a_
-	a (Lepn;)V func_230988_a_
-	a (Z)I func_230989_a_
+	a (DD)V func_230982_a_ onClick
+	a (DDDD)V func_230983_a_ onDrag
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;Ldlx;II)V func_230441_a_ renderBg
+	a (Lepn;)V func_230988_a_ playDownSound
+	a (Z)I func_230989_a_ getYImage
 	b ()V func_230979_b_
 	b (D)V func_230980_b_
-	c ()Lmx; func_230442_c_
-	a_ (DD)V func_231000_a__
+	c ()Lmx; func_230442_c_ getNarrationMessage
+	a_ (DD)V func_231000_a__ onRelease
 dng net/minecraft/client/gui/widget/Widget
-	a field_230684_a_
-	b field_230685_b_
-	c field_230686_c_
-	i field_230687_i_
-	j field_230688_j_
-	k field_230689_k_
-	l field_230690_l_
-	m field_230691_m_
-	n field_230692_n_
-	o field_230693_o_
-	p field_230694_p_
-	q field_230695_q_
-	r field_230696_r_
-	a (DD)V func_230982_a_
-	a (DDDD)V func_230983_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
-	a (F)V func_230986_a_
-	a (I)Z func_230987_a_
-	a (Ldhl;II)V func_230443_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldhl;Ldlx;II)V func_230441_a_
-	a (Lepn;)V func_230988_a_
-	a (Lmr;)V func_238482_a_
-	a (Z)I func_230989_a_
-	b (DD)Z func_231047_b_
-	b (I)V func_230991_b_
-	b (Ldhl;IIF)V func_230431_b_
-	c ()Lmx; func_230442_c_
-	c (DD)Z func_230992_c_
-	c (DDI)Z func_231048_c_
-	c (I)V func_230994_c_
-	c (Z)V func_230995_c_
-	d (Z)V func_230996_d_
-	e ()I func_238483_d_
-	f ()V func_230997_f_
-	g ()Z func_230449_g_
-	h ()I func_230998_h_
-	i ()Lmr; func_230458_i_
-	j ()Z func_230999_j_
-	a_ (DD)V func_231000_a__
-	c_ (Z)Z func_231049_c__
+	a field_230684_a_ message
+	b field_230685_b_ wasHovered
+	c field_230686_c_ focused
+	i field_230687_i_ WIDGETS_LOCATION
+	j field_230688_j_ width
+	k field_230689_k_ height
+	l field_230690_l_ x
+	m field_230691_m_ y
+	n field_230692_n_ isHovered
+	o field_230693_o_ active
+	p field_230694_p_ visible
+	q field_230695_q_ alpha
+	r field_230696_r_ nextNarration
+	a (DD)V func_230982_a_ onClick
+	a (DDDD)V func_230983_a_ onDrag
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
+	a (F)V func_230986_a_ setAlpha
+	a (I)Z func_230987_a_ isValidClickButton
+	a (Ldhl;II)V func_230443_a_ renderToolTip
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldhl;Ldlx;II)V func_230441_a_ renderBg
+	a (Lepn;)V func_230988_a_ playDownSound
+	a (Lmr;)V func_238482_a_ setMessage
+	a (Z)I func_230989_a_ getYImage
+	b (DD)Z func_231047_b_ isMouseOver
+	b (I)V func_230991_b_ setWidth
+	b (Ldhl;IIF)V func_230431_b_ renderButton
+	c ()Lmx; func_230442_c_ getNarrationMessage
+	c (DD)Z func_230992_c_ clicked
+	c (DDI)Z func_231048_c_ mouseReleased
+	c (I)V func_230994_c_ queueNarration
+	c (Z)V func_230995_c_ onFocusedChanged
+	d (Z)V func_230996_d_ setFocused
+	e ()I func_238483_d_ getWidth
+	f ()V func_230997_f_ narrate
+	g ()Z func_230449_g_ isHovered
+	h ()I func_230998_h_ getWidth
+	i ()Lmr; func_230458_i_ getMessage
+	j ()Z func_230999_j_ isFocused
+	a_ (DD)V func_231000_a__ onRelease
+	c_ (Z)Z func_231049_c__ changeFocus
 dnh net/minecraft/client/gui/overlay/BossOverlayGui
 	a field_184058_a
 	b field_184059_f
@@ -52762,13 +52762,13 @@ dnh net/minecraft/client/gui/overlay/BossOverlayGui
 	d ()Z func_184053_e
 	e ()Z func_184056_f
 dni net/minecraft/client/gui/widget/button/Button
-	s field_238486_s_
-	t field_230697_t_
-	u field_238487_u_
-	a (Ldhl;II)V func_230443_a_
+	s field_238486_s_ DEFAULT_ON_TOOLTIP
+	t field_230697_t_ onPress
+	u field_238487_u_ onTooltip
+	a (Ldhl;II)V func_230443_a_ renderToolTip
 	a (Ldni;Ldhl;II)V func_238488_a_
-	b ()V func_230930_b_
-	b (Ldhl;IIF)V func_230431_b_
+	b ()V func_230930_b_ onPress
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dni$a net/minecraft/client/gui/widget/button/Button$IPressable
 	onPress (Ldni;)V onPress
 dni$b net/minecraft/client/gui/widget/button/Button$ITooltip
@@ -52813,8 +52813,8 @@ dnk net/minecraft/client/gui/widget/button/CheckboxButton
 	b field_212943_a
 	c field_238499_c_
 	a ()Z func_212942_a
-	b ()V func_230930_b_
-	b (Ldhl;IIF)V func_230431_b_
+	b ()V func_230930_b_ onPress
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dnl net/minecraft/client/gui/CommandSuggestionHelper
 	a field_228092_a_
 	b field_228093_b_
@@ -52889,15 +52889,15 @@ dnm net/minecraft/client/gui/RenderComponentsUtil
 	a (Ljava/lang/String;)Ljava/lang/String; func_238504_a_
 	a (Lmu;ILdmt;)Ljava/util/List; func_238505_a_
 dnn net/minecraft/client/gui/widget/list/AbstractOptionList
-	f (I)Z func_230957_f_
-	c_ (Z)Z func_231049_c__
+	f (I)Z func_230957_f_ isSelectedItem
+	c_ (Z)Z func_231049_c__ changeFocus
 dnn$a net/minecraft/client/gui/widget/list/AbstractOptionList$Entry
 	a field_214380_a
 	b field_214381_b
-	a (Ldof;)V func_231035_a_
-	r ()Ldof; func_241217_q_
-	b_ (Z)V func_231037_b__
-	aw_ ()Z func_231041_ay__
+	a (Ldof;)V func_231035_a_ setFocused
+	r ()Ldof; func_241217_q_ getFocused
+	b_ (Z)V func_231037_b__ setDragging
+	aw_ ()Z func_231041_ay__ isDragging
 dno net/minecraft/client/gui/overlay/DebugOverlayGui
 	a field_212923_a
 	b field_175242_a
@@ -52950,10 +52950,10 @@ dnp net/minecraft/client/gui/widget/TextFieldWidget
 	C field_175209_y
 	D field_195613_A
 	a ()V func_146178_a
-	a (CI)Z func_231042_a_
-	a (DDI)Z func_231044_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (II)I func_146183_a
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (IIII)V func_146188_c
 	a (IIZ)I func_146197_a
 	a (Ljava/lang/String;)V func_146180_a
@@ -52962,12 +52962,12 @@ dnp net/minecraft/client/gui/widget/TextFieldWidget
 	a (Ljava/util/function/Consumer;)V func_212954_a
 	a (Ljava/util/function/Predicate;)V func_200675_a
 	b ()Ljava/lang/String; func_146179_b
-	b (DD)Z func_231047_b_
-	b (Ldhl;IIF)V func_230431_b_
+	b (DD)Z func_231047_b_ isMouseOver
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 	b (Ljava/lang/String;)V func_146191_b
-	c ()Lmx; func_230442_c_
+	c ()Lmx; func_230442_c_ getNarrationMessage
 	c (Ljava/lang/String;)V func_195612_c
-	c (Z)V func_230995_c_
+	c (Z)V func_230995_c_ onFocusedChanged
 	d ()Ljava/lang/String; func_146207_c
 	d (I)V func_146177_a
 	d (Ljava/lang/String;)V func_212951_d
@@ -52998,7 +52998,7 @@ dnp net/minecraft/client/gui/widget/TextFieldWidget
 	r (I)I func_238516_r_
 	s ()Z func_146181_i
 	t ()Z func_212953_l
-	c_ (Z)Z func_231049_c__
+	c_ (Z)Z func_231049_c__ changeFocus
 dnq net/minecraft/client/gui/widget/button/ImageButton
 	a field_191750_o
 	b field_191747_p
@@ -53007,7 +53007,7 @@ dnq net/minecraft/client/gui/widget/button/ImageButton
 	e field_212935_e
 	v field_212936_f
 	a (II)V func_191746_c
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dnr net/minecraft/client/gui/ClientBossInfo
 	h field_186766_h
 	i field_186767_i
@@ -53019,8 +53019,8 @@ dnr$1 net/minecraft/client/gui/ClientBossInfo$1
 dns net/minecraft/client/gui/widget/button/LockIconButton
 	a field_175231_o
 	a ()Z func_175230_c
-	b (Ldhl;IIF)V func_230431_b_
-	c ()Lmx; func_230442_c_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
+	c ()Lmx; func_230442_c_ getNarrationMessage
 	e (Z)V func_175229_b
 dns$a net/minecraft/client/gui/widget/button/LockIconButton$Icon
 	a LOCKED
@@ -53038,9 +53038,9 @@ dns$a net/minecraft/client/gui/widget/button/LockIconButton$Icon
 	valueOf (Ljava/lang/String;)Ldns$a; valueOf
 dnt net/minecraft/client/gui/widget/list/ExtendedList
 	a field_230698_a_
-	c_ (Z)Z func_231049_c__
+	c_ (Z)Z func_231049_c__ changeFocus
 dnt$a net/minecraft/client/gui/widget/list/ExtendedList$AbstractListEntry
-	c_ (Z)Z func_231049_c__
+	c_ (Z)Z func_231049_c__ changeFocus
 dnu net/minecraft/client/gui/widget/button/OptionButton
 	a field_146137_o
 	a ()Ldma; func_238517_a_
@@ -53049,16 +53049,16 @@ dnv net/minecraft/client/gui/widget/list/OptionsRowList
 	a (Ldma;Ldma;)V func_214334_a
 	a ([Ldma;)V func_214335_a
 	c (DD)Ljava/util/Optional; func_238518_c_
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 dnv$a net/minecraft/client/gui/widget/list/OptionsRowList$Row
 	a field_214385_a
 	a (ILdhl;IIFLdng;)V func_238519_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldmb;ILdma;)Ldnv$a; func_214384_a
 	a (Ldmb;ILdma;Ldma;)Ldnv$a; func_214382_a
 	a (Ldnv$a;)Ljava/util/List; func_238520_a_
-	av_ ()Ljava/util/List; func_231039_at__
+	av_ ()Ljava/util/List; func_231039_at__ children
 dnw net/minecraft/client/gui/overlay/PlayerTabOverlayGui
 	a field_175252_a
 	b field_175250_f
@@ -53094,7 +53094,7 @@ dny net/minecraft/client/gui/widget/ToggleWidget
 	a ()Z func_191754_c
 	a (II)V func_191752_c
 	a (IIIILuh;)V func_191751_a
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 	e (Z)V func_191753_b
 dnz net/minecraft/client/gui/overlay/SubtitleOverlayGui
 	a field_184069_a
@@ -53112,50 +53112,50 @@ dnz$a net/minecraft/client/gui/overlay/SubtitleOverlayGui$Subtitle
 	b ()J func_186825_b
 	c ()Ldem; func_186826_c
 doa net/minecraft/client/gui/screen/IScreen
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 dob net/minecraft/client/gui/widget/SoundSlider
 	c field_212933_a
 	a ()V func_230972_a_
 	b ()V func_230979_b_
 doc net/minecraft/client/gui/IRenderable
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 dod net/minecraft/client/gui/FocusableGui
-	a field_230699_a_
-	b field_230700_b_
-	a (Ldof;)V func_231035_a_
-	r ()Ldof; func_241217_q_
-	b_ (Z)V func_231037_b__
-	aw_ ()Z func_231041_ay__
+	a field_230699_a_ focused
+	b field_230700_b_ isDragging
+	a (Ldof;)V func_231035_a_ setFocused
+	r ()Ldof; func_241217_q_ getFocused
+	b_ (Z)V func_231037_b__ setDragging
+	aw_ ()Z func_231041_ay__ isDragging
 doe net/minecraft/client/gui/INestedGuiEventHandler
-	a (CI)Z func_231042_a_
-	a (DDD)Z func_231043_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (DDD)Z func_231043_a_ mouseScrolled
 	a (DDDLdof;)Z func_212929_a
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
 	a (DDILdof;)Z func_212931_a
-	a (III)Z func_231046_a_
-	a (Ldof;)V func_231035_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldof;)V func_231035_a_ setFocused
 	b (III)Z func_223281_a_
 	b (Ldof;)V func_212928_a
-	c (DDI)Z func_231048_c_
+	c (DDI)Z func_231048_c_ mouseReleased
 	c (Ldof;)V func_212932_b
 	d (DD)Ljava/util/Optional; func_212930_a
-	r ()Ldof; func_241217_q_
-	b_ (Z)V func_231037_b__
-	c_ (Z)Z func_231049_c__
-	av_ ()Ljava/util/List; func_231039_at__
-	aw_ ()Z func_231041_ay__
+	r ()Ldof; func_241217_q_ getFocused
+	b_ (Z)V func_231037_b__ setDragging
+	c_ (Z)Z func_231049_c__ changeFocus
+	av_ ()Ljava/util/List; func_231039_at__ children
+	aw_ ()Z func_231041_ay__ isDragging
 dof net/minecraft/client/gui/IGuiEventListener
-	a (CI)Z func_231042_a_
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
-	a (III)Z func_231046_a_
-	b (DD)Z func_231047_b_
+	a (CI)Z func_231042_a_ charTyped
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
+	a (III)Z func_231046_a_ keyPressed
+	b (DD)Z func_231047_b_ isMouseOver
 	b (III)Z func_223281_a_
-	c (DDI)Z func_231048_c_
+	c (DDI)Z func_231048_c_ mouseReleased
 	e (DD)V func_212927_b
-	c_ (Z)Z func_231049_c__
+	c_ (Z)Z func_231049_c__ changeFocus
 doi net/minecraft/client/gui/SpectatorGui
 	a field_175269_a
 	b field_175267_f
@@ -53538,9 +53538,9 @@ dpg net/minecraft/client/gui/fonts/providers/TrueTypeGlyphProviderFactory
 dpj net/minecraft/client/gui/AccessibilityScreen
 	c field_212986_a
 	p field_212989_d
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_212984_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	c ()V func_212985_a
 dpk net/minecraft/client/gui/screen/AlertScreen
 	a field_201550_f
@@ -53548,10 +53548,10 @@ dpk net/minecraft/client/gui/screen/AlertScreen
 	c field_201552_h
 	p field_201553_i
 	q field_201549_s
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_212983_a
-	b ()V func_231160_c_
-	d ()V func_231023_e_
+	b ()V func_231160_c_ init
+	d ()V func_231023_e_ tick
 dpl net/minecraft/client/gui/screen/ConfirmBackupScreen
 	a field_212109_a
 	b field_212110_s
@@ -53559,21 +53559,21 @@ dpl net/minecraft/client/gui/screen/ConfirmBackupScreen
 	p field_212994_d
 	q field_212112_u
 	r field_212996_j
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_212991_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_212992_b
 	c (Ldni;)V func_212993_c
-	at_ ()Z func_231178_ax__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dpl$a net/minecraft/client/gui/screen/ConfirmBackupScreen$ICallback
 	proceed (ZZ)V proceed
 dpm net/minecraft/client/gui/screen/ChatOptionsScreen
 	c field_146399_a
 	p field_193025_i
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_212990_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	f ()V func_193024_a
 dpn net/minecraft/client/gui/screen/ChatScreen
 	a field_146415_a
@@ -53581,31 +53581,31 @@ dpn net/minecraft/client/gui/screen/ChatScreen
 	c field_146416_h
 	p field_146409_v
 	q field_228174_e_
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)V func_146402_a
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldpn;)Ldnl; func_228175_a_
 	a (Ljava/lang/String;)V func_212997_a
-	a (Ljava/lang/String;Z)V func_231155_a_
-	b ()V func_231160_c_
+	a (Ljava/lang/String;Z)V func_231155_a_ insertText
+	b ()V func_231160_c_ init
 	b (Ljava/lang/String;)V func_208604_b
-	d ()V func_231023_e_
-	e ()V func_231164_f_
-	ax_ ()Z func_231177_au__
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
+	ax_ ()Z func_231177_au__ isPauseScreen
 dpn$1 net/minecraft/client/gui/screen/ChatScreen$1
 	a field_228176_a_
-	c ()Lmx; func_230442_c_
+	c ()Lmx; func_230442_c_ getNarrationMessage
 dpo net/minecraft/client/gui/screen/ConfirmOpenLinkScreen
 	p field_146363_r
 	q field_146362_s
 	r field_146361_t
 	s field_146360_u
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213004_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213005_b
 	c (Ldni;)V func_213006_c
 	g ()V func_146359_e
@@ -53617,14 +53617,14 @@ dpp net/minecraft/client/gui/screen/ConfirmScreen
 	q field_175298_s
 	r field_146353_s
 	a (I)V func_146350_a
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213001_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213002_b
-	d ()V func_231023_e_
-	as_ ()Ljava/lang/String; func_231167_h_
-	at_ ()Z func_231178_ax__
+	d ()V func_231023_e_ tick
+	as_ ()Ljava/lang/String; func_231167_h_ getNarrationMessage
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dpq net/minecraft/client/gui/screen/ConnectingScreen
 	a field_146372_a
 	b field_146370_f
@@ -53633,19 +53633,19 @@ dpq net/minecraft/client/gui/screen/ConnectingScreen
 	q field_146374_i
 	r field_209515_s
 	s field_213000_g
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_212999_a
 	a (Ldpq;)Z access$000
 	a (Ldpq;Lme;)Lme; access$102
 	a (Ldpq;Lmr;)V func_209513_a
 	a (Ljava/lang/String;I)V func_146367_a
 	a (Lmr;)V func_209514_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldpq;)Lme; access$100
 	c (Ldpq;)Ldqs; access$200
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	g ()Lorg/apache/logging/log4j/Logger; access$300
-	at_ ()Z func_231178_ax__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dpq$1 net/minecraft/client/gui/screen/ConnectingScreen$1
 	a field_148231_a
 	b field_148229_b
@@ -53660,28 +53660,28 @@ dpr net/minecraft/client/gui/screen/CreateBuffetWorldScreen
 	c field_205311_s
 	p field_238593_p_
 	q field_205313_u
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213015_c
 	a (Ldpr$a$a;)Z func_241578_a_
 	a (Ldpr;)V func_238595_a_
 	a (Ldpr;Lbre;)Lbre; func_238596_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_241579_b_
 	i ()V func_205306_h
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dpr$1 net/minecraft/client/gui/screen/CreateBuffetWorldScreen$1
 dpr$a net/minecraft/client/gui/screen/CreateBuffetWorldScreen$BiomeList
 	a field_205303_v
 	a (Lbre;)V func_238597_a_
-	a (Ldne$a;)V func_241215_a_
-	a (Ldpr$a$a;)V func_241215_a_
-	b ()Z func_230971_aw__
+	a (Ldne$a;)V func_241215_a_ setSelected
+	a (Ldpr$a$a;)V func_241215_a_ setSelected
+	b ()Z func_230971_aw__ isFocused
 	b (Lbre;)Ljava/lang/String; func_238598_b_
 dpr$a$a net/minecraft/client/gui/screen/CreateBuffetWorldScreen$BiomeList$BiomeEntry
 	a field_214393_a
 	b field_238599_b_
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldpr$a$a;)Lbre; func_238600_a_
 dps net/minecraft/client/gui/screen/CreateFlatWorldScreen
 	a field_146385_f
@@ -53692,10 +53692,10 @@ dps net/minecraft/client/gui/screen/CreateFlatWorldScreen
 	r field_146390_s
 	s field_146386_v
 	a (Lcra;)V func_238602_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213009_a
 	a (Ldps;)Lcra; access$000
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213010_b
 	b (Ldps;)V func_241580_b_
 	c (Ldni;)V func_213011_c
@@ -53703,21 +53703,21 @@ dps net/minecraft/client/gui/screen/CreateFlatWorldScreen
 	i ()Lcra; func_238603_g_
 	k ()V func_146375_g
 	l ()Z func_146382_i
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dps$1 net/minecraft/client/gui/screen/CreateFlatWorldScreen$1
 dps$a net/minecraft/client/gui/screen/CreateFlatWorldScreen$DetailsList
 	a field_148227_l
-	a (Ldne$a;)V func_241215_a_
-	a (Ldps$a$a;)V func_241215_a_
+	a (Ldne$a;)V func_241215_a_ setSelected
+	a (Ldps$a$a;)V func_241215_a_ setSelected
 	a (Ldps$a;)Ldlx; func_241581_a_
-	b ()Z func_230971_aw__
-	e ()I func_230952_d_
+	b ()Z func_230971_aw__ isFocused
+	e ()I func_230952_d_ getScrollbarPosition
 	f ()V func_214345_a
 dps$a$a net/minecraft/client/gui/screen/CreateFlatWorldScreen$DetailsList$LayerEntry
 	a field_214391_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (Ldhl;II)V func_238604_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;IILbki;)V func_238605_a_
 dpt net/minecraft/client/gui/screen/DataPackScreen
 	a field_238606_a_
@@ -53726,32 +53726,32 @@ dpt net/minecraft/client/gui/screen/DataPackScreen
 dpu net/minecraft/client/gui/screen/DatapackFailureScreen
 	a field_238619_a_
 	b field_238620_b_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_238621_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_238622_b_
-	at_ ()Z func_231178_ax__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dpv net/minecraft/client/gui/screen/DeathScreen
 	a field_146347_a
 	b field_184871_f
 	c field_213023_c
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)Lnb; func_238623_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213020_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213021_b
 	c (Z)V func_213022_a
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	i ()V func_228177_a_
-	at_ ()Z func_231178_ax__
-	ax_ ()Z func_231177_au__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
+	ax_ ()Z func_231177_au__ isPauseScreen
 dpw net/minecraft/client/gui/screen/DemoScreen
 	a field_146348_f
-	a (Ldhl;)V func_230446_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;)V func_230446_a_ renderBackground
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213018_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213019_b
 dpx net/minecraft/client/gui/screen/ServerListScreen
 	a field_195170_a
@@ -53759,27 +53759,27 @@ dpx net/minecraft/client/gui/screen/ServerListScreen
 	c field_146302_g
 	p field_213027_d
 	q field_228178_e_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_213025_a
 	a (Ljava/lang/String;)V func_213024_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213026_b
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()V func_195167_h
 	k ()V func_195168_i
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dpy net/minecraft/client/gui/screen/DisconnectedScreen
 	a field_146304_f
 	b field_146305_g
 	c field_146307_h
 	p field_175353_i
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213033_a
-	b ()V func_231160_c_
-	at_ ()Z func_231178_ax__
+	b ()V func_231160_c_ init
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dpz net/minecraft/client/gui/screen/AddServerScreen
 	a field_195179_a
 	b field_213032_b
@@ -53789,70 +53789,70 @@ dpz net/minecraft/client/gui/screen/AddServerScreen
 	r field_152176_i
 	s field_228179_g_
 	t field_181032_r
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_213029_a
 	a (Ldys$a;)Lmr; func_238624_a_
 	a (Ljava/lang/String;)V func_213028_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213030_b
 	b (Ljava/lang/String;)Z func_210141_a
 	c (Ldni;)V func_213031_c
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()V func_195172_h
 	k ()V func_228180_b_
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dqa net/minecraft/client/gui/screen/ErrorScreen
 	a field_146312_f
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213034_a
-	b ()V func_231160_c_
-	at_ ()Z func_231178_ax__
+	b ()V func_231160_c_ init
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dqb net/minecraft/client/gui/screen/DirtMessageScreen
-	a (Ldhl;IIF)V func_230430_a_
-	at_ ()Z func_231178_ax__
+	a (Ldhl;IIF)V func_230430_a_ render
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dqc net/minecraft/client/gui/screen/SleepInMultiplayerScreen
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Ldni;)V func_212998_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	i ()V func_146418_g
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dqd net/minecraft/client/gui/screen/LanguageScreen
 	c field_146450_f
 	p field_146454_h
 	q field_211832_i
 	r field_146452_r
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213036_a
 	a (Ldqd;)Lems; func_213035_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213037_b
 dqd$a net/minecraft/client/gui/screen/LanguageScreen$List
 	a field_148178_k
-	a (Ldhl;)V func_230433_a_
-	a (Ldne$a;)V func_241215_a_
-	a (Ldqd$a$a;)V func_241215_a_
+	a (Ldhl;)V func_230433_a_ renderBackground
+	a (Ldne$a;)V func_241215_a_ setSelected
+	a (Ldqd$a$a;)V func_241215_a_ setSelected
 	a (Ldqd$a;)I func_214349_a
-	b ()Z func_230971_aw__
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	b ()Z func_230971_aw__ isFocused
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 dqd$a$a net/minecraft/client/gui/screen/LanguageScreen$List$LanguageEntry
 	a field_214397_a
 	b field_214398_b
 	a ()V func_214395_a
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldqd$a$a;)Lemr; func_214396_a
 dqe net/minecraft/client/gui/screen/WorldLoadProgressScreen
 	a field_213040_a
 	b field_213041_b
 	c field_213042_c
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Lzq;IIII)V func_238625_a_
 	a (Lit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;)V func_213039_a
-	e ()V func_231164_f_
-	at_ ()Z func_231178_ax__
+	e ()V func_231164_f_ removed
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dqf net/minecraft/client/gui/ResourceLoadProgressGui
 	a field_212973_a
 	b field_238627_b_
@@ -53865,7 +53865,7 @@ dqf net/minecraft/client/gui/ResourceLoadProgressGui
 	l field_212979_g
 	m field_212980_h
 	a ()Z func_212969_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IIIIF)V func_238629_a_
 	a (Ldlx;)V func_212970_a
 	b ()Luh; func_212971_b
@@ -53885,9 +53885,9 @@ dqh net/minecraft/client/gui/screen/MouseSettingsScreen
 	c field_213045_b
 	p field_213046_c
 	a (I)[Ldma; func_223702_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_223703_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 dqi net/minecraft/client/gui/screen/OptionsScreen
 	a field_146440_f
 	b field_146441_g
@@ -53897,14 +53897,14 @@ dqi net/minecraft/client/gui/screen/OptionsScreen
 	r field_213062_f
 	a (Laar;)V func_241584_a_
 	a (Land;)Lmr; func_238630_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213056_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213058_b
 	c (Ldni;)V func_213060_c
 	c (Z)V func_213050_a
 	d (Ldni;)V func_213049_d
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_213053_e
 	f (Ldni;)V func_213052_f
 	g (Ldni;)V func_213059_g
@@ -53916,27 +53916,27 @@ dqi net/minecraft/client/gui/screen/OptionsScreen
 dqj net/minecraft/client/gui/screen/SettingsScreen
 	a field_228182_a_
 	b field_228183_b_
-	e ()V func_231164_f_
-	au_ ()V func_231175_as__
+	e ()V func_231164_f_ removed
+	au_ ()V func_231175_as__ onClose
 dqk net/minecraft/client/gui/screen/MemoryErrorScreen
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213047_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213048_b
-	at_ ()Z func_231178_ax__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dql net/minecraft/client/gui/LoadingGui
 	a ()Z func_212969_a
 dqm net/minecraft/client/gui/screen/IngameMenuScreen
 	a field_222813_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213067_a
 	a (Ljava/lang/String;Ldni;)V func_213072_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213068_b
 	c (Ldni;)V func_213071_c
 	c (Ljava/lang/String;Z)V func_213069_a
 	c (Z)V func_213064_a
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_213063_d
 	e (Ldni;)V func_213066_e
 	f (Ldni;)V func_213065_f
@@ -53948,10 +53948,10 @@ dqn net/minecraft/client/gui/screen/GPUWarningScreen
 	c field_241587_c_
 	p field_241588_p_
 	q field_241589_q_
-	a (Ldhl;IIF)V func_230430_a_
-	b (Ldlx;II)V func_231158_b_
-	as_ ()Ljava/lang/String; func_231167_h_
-	at_ ()Z func_231178_ax__
+	a (Ldhl;IIF)V func_230430_a_ render
+	b (Ldlx;II)V func_231158_b_ init
+	as_ ()Ljava/lang/String; func_231167_h_ getNarrationMessage
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dqn$a net/minecraft/client/gui/screen/GPUWarningScreen$Option
 	a field_241590_a_
 	b field_241591_b_
@@ -53967,10 +53967,10 @@ dqo net/minecraft/client/gui/screen/FlatPresetsScreen
 	s field_146434_t
 	t field_146433_u
 	u field_241594_u_
-	a (DDD)Z func_231043_a_
+	a (DDD)Z func_231043_a_ mouseScrolled
 	a (Lcra;)Ljava/lang/String; func_238633_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_238634_a_
 	a (Ldqo;)Ldnp; func_238635_a_
 	a (Ldqo;Lcra;)Lcra; func_241595_a_
@@ -53979,14 +53979,14 @@ dqo net/minecraft/client/gui/screen/FlatPresetsScreen
 	a (Ljava/lang/String;Lcra;)Lcra; func_241596_a_
 	a (Lmr;Lbqa;Lbre;Ljava/util/List;ZZZ[Lcqz;)V func_238640_a_
 	a (Luh;)Ljava/lang/IllegalArgumentException; func_238641_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Lcra;)Ljava/lang/String; func_238642_b_
 	b (Ldni;)V func_213076_a
 	c (Z)V func_213074_a
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()Ljava/util/List; func_213073_a
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dqo$a net/minecraft/client/gui/screen/FlatPresetsScreen$LayerItem
 	a field_148234_a
 	b field_148232_b
@@ -53994,17 +53994,17 @@ dqo$a net/minecraft/client/gui/screen/FlatPresetsScreen$LayerItem
 	a ()Lmr; func_238644_a_
 dqo$b net/minecraft/client/gui/screen/FlatPresetsScreen$SlotList
 	a field_148174_l
-	a (III)Z func_231046_a_
-	a (Ldne$a;)V func_241215_a_
-	a (Ldqo$b$a;)V func_241215_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldne$a;)V func_241215_a_ setSelected
+	a (Ldqo$b$a;)V func_241215_a_ setSelected
 	a (Ldqo$b;)Ldlx; func_238645_a_
-	b ()Z func_230971_aw__
+	b ()Z func_230971_aw__ isFocused
 dqo$b$a net/minecraft/client/gui/screen/FlatPresetsScreen$SlotList$PresetEntry
 	a field_214403_a
 	a ()V func_214399_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (Ldhl;II)V func_238646_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;IILbke;)V func_238647_a_
 	a (Ldqo$b$a;)V func_214401_a
 dqp net/minecraft/client/gui/screen/WorkingScreen
@@ -54014,81 +54014,81 @@ dqp net/minecraft/client/gui/screen/WorkingScreen
 	p field_146592_h
 	a ()V func_146586_a
 	a (I)V func_73718_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Lmr;)V func_200210_a
 	b (Lmr;)V func_200211_b
 	c (Lmr;)V func_200209_c
-	at_ ()Z func_231178_ax__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
 dqq net/minecraft/client/gui/screen/DownloadTerrainScreen
-	a (Ldhl;IIF)V func_230430_a_
-	at_ ()Z func_231178_ax__
-	ax_ ()Z func_231177_au__
+	a (Ldhl;IIF)V func_230430_a_ render
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
+	ax_ ()Z func_231177_au__ isPauseScreen
 dqr net/minecraft/client/gui/screen/ResourcePacksScreen
 	a (Laar;Ljava/util/function/Consumer;Ljava/lang/Runnable;)Ldtf; func_241597_a_
 dqs net/minecraft/client/gui/screen/Screen
-	a field_230701_a_
-	b field_230702_b_
-	c field_230703_c_
-	d field_230704_d_
-	e field_230705_e_
-	i field_230706_i_
-	j field_230707_j_
-	k field_230708_k_
-	l field_230709_l_
-	m field_230710_m_
-	n field_230711_n_
-	o field_230712_o_
+	a field_230701_a_ LOGGER
+	b field_230702_b_ ALLOWED_PROTOCOLS
+	c field_230703_c_ clickedLink
+	d field_230704_d_ title
+	e field_230705_e_ children
+	i field_230706_i_ minecraft
+	j field_230707_j_ itemRenderer
+	k field_230708_k_ width
+	l field_230709_l_ height
+	m field_230710_m_ buttons
+	n field_230711_n_ passEvents
+	o field_230712_o_ font
 	a (II)V func_231149_a_
-	a (III)Z func_231046_a_
-	a (Lbki;)Ljava/util/List; func_231151_a_
-	a (Ldhl;)V func_230446_a_
-	a (Ldhl;I)V func_238651_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldhl;Lbki;II)V func_230457_a_
-	a (Ldhl;Lmu;II)V func_238652_a_
-	a (Ldhl;Lnb;II)V func_238653_a_
-	a (Ldlx;II)V func_231152_a_
-	a (Ldng;)Ldng; func_230480_a_
-	a (Ljava/lang/Runnable;Ljava/lang/String;Ljava/lang/String;)V func_231153_a_
-	a (Ljava/lang/String;CI)Z func_231154_a_
-	a (Ljava/lang/String;Z)V func_231155_a_
-	a (Ljava/net/URI;)V func_231156_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Lbki;)Ljava/util/List; func_231151_a_ getTooltipFromItem
+	a (Ldhl;)V func_230446_a_ renderBackground
+	a (Ldhl;I)V func_238651_a_ renderBackground
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldhl;Lbki;II)V func_230457_a_ renderTooltip
+	a (Ldhl;Lmu;II)V func_238652_a_ renderTooltip
+	a (Ldhl;Lnb;II)V func_238653_a_ renderComponentHoverEffect
+	a (Ldlx;II)V func_231152_a_ resize
+	a (Ldng;)Ldng; func_230480_a_ addButton
+	a (Ljava/lang/Runnable;Ljava/lang/String;Ljava/lang/String;)V func_231153_a_ wrapScreenError
+	a (Ljava/lang/String;CI)Z func_231154_a_ isValidCharacterForName
+	a (Ljava/lang/String;Z)V func_231155_a_ insertText
+	a (Ljava/net/URI;)V func_231156_a_ openLink
 	a (Ljava/util/List;)V func_230476_a_
-	a (Lnb;)Z func_230455_a_
-	b ()V func_231160_c_
-	b (DD)Z func_231047_b_
-	b (Ldhl;Ljava/util/List;II)V func_238654_b_
-	b (Ldlx;II)V func_231158_b_
+	a (Lnb;)Z func_230455_a_ handleComponentClicked
+	b ()V func_231160_c_ init
+	b (DD)Z func_231047_b_ isMouseOver
+	b (Ldhl;Ljava/util/List;II)V func_238654_b_ renderTooltip
+	b (Ldlx;II)V func_231158_b_ init
 	b (Ljava/lang/String;)Ljava/lang/String; func_229875_lam_
-	b (Ljava/lang/String;Z)V func_231159_b_
-	c (Ljava/lang/String;)V func_231161_c_
-	c (Z)V func_231162_c_
-	d ()V func_231023_e_
-	d (Ldof;)Ldof; func_230481_d_
-	e ()V func_231164_f_
-	f (I)V func_231165_f_
-	g (I)Z func_231166_g_
-	h (I)Z func_231168_h_
-	i (I)Z func_231169_i_
-	j (I)Z func_231170_j_
-	p ()Lmr; func_231171_q_
-	q ()Z func_231172_r_
-	s ()Z func_231173_s_
-	t ()Z func_231174_t_
-	as_ ()Ljava/lang/String; func_231167_h_
-	at_ ()Z func_231178_ax__
-	au_ ()V func_231175_as__
-	av_ ()Ljava/util/List; func_231039_at__
-	ax_ ()Z func_231177_au__
+	b (Ljava/lang/String;Z)V func_231159_b_ sendMessage
+	c (Ljava/lang/String;)V func_231161_c_ sendMessage
+	c (Z)V func_231162_c_ confirmLink
+	d ()V func_231023_e_ tick
+	d (Ldof;)Ldof; func_230481_d_ addListener
+	e ()V func_231164_f_ removed
+	f (I)V func_231165_f_ renderDirtBackground
+	g (I)Z func_231166_g_ isCut
+	h (I)Z func_231168_h_ isPaste
+	i (I)Z func_231169_i_ isCopy
+	j (I)Z func_231170_j_ isSelectAll
+	p ()Lmr; func_231171_q_ getTitle
+	q ()Z func_231172_r_ hasControlDown
+	s ()Z func_231173_s_ hasShiftDown
+	t ()Z func_231174_t_ hasAltDown
+	as_ ()Ljava/lang/String; func_231167_h_ getNarrationMessage
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
+	au_ ()V func_231175_as__ onClose
+	av_ ()Ljava/util/List; func_231039_at__ children
+	ax_ ()Z func_231177_au__ isPauseScreen
 dqt net/minecraft/client/gui/screen/ShareToLanScreen
 	a field_146598_a
 	b field_146596_f
 	c field_146597_g
 	p field_146599_h
 	q field_146600_i
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213083_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213084_b
 	c (Ldni;)V func_213085_c
 	d (Ldni;)V func_213082_d
@@ -54096,14 +54096,14 @@ dqt net/minecraft/client/gui/screen/ShareToLanScreen
 dqu net/minecraft/client/gui/screen/CustomizeSkinScreen
 	a (Lbed;)Lmr; func_238655_a_
 	a (Lbed;Ldni;)V func_213080_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213079_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213081_b
 dqv net/minecraft/client/gui/screen/OptionsSoundsScreen
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213104_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213105_b
 dqw net/minecraft/client/gui/screen/MainMenuScreen
 	a field_213098_a
@@ -54122,22 +54122,22 @@ dqw net/minecraft/client/gui/screen/MainMenuScreen
 	z field_209101_K
 	A field_213102_y
 	B field_213103_z
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Ljava/lang/Integer;Ljava/lang/Integer;)V func_238657_a_
 	a (Ldni;)V func_238658_a_
 	a (Ldni;Ldhl;II)V func_238659_a_
 	a (Lelw;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture; func_213097_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (II)V func_73969_a
 	b (Ldhl;Ljava/lang/Integer;Ljava/lang/Integer;)V func_238660_b_
 	b (Ldni;)V func_213091_a
 	c (II)V func_73972_b
 	c (Ldni;)V func_238661_c_
 	c (Z)V func_213087_a
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_213095_c
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_213089_e
 	f (Ldni;)V func_213088_f
 	g (Ldni;)V func_213094_g
@@ -54145,8 +54145,8 @@ dqw net/minecraft/client/gui/screen/MainMenuScreen
 	i ()Z func_183501_a
 	i (Ldni;)V func_213090_i
 	k ()V func_140005_i
-	at_ ()Z func_231178_ax__
-	ax_ ()Z func_231177_au__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
+	ax_ ()Z func_231177_au__ isPauseScreen
 dqx net/minecraft/client/gui/screen/VideoSettingsScreen
 	c field_241598_c_
 	p field_241599_p_
@@ -54159,15 +54159,15 @@ dqx net/minecraft/client/gui/screen/VideoSettingsScreen
 	w field_146501_h
 	x field_241604_x_
 	y field_213108_e
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_241605_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_241606_b_
 	b (Ljava/util/List;)V func_241607_b_
-	c (DDI)Z func_231048_c_
+	c (DDI)Z func_231048_c_ mouseReleased
 	c (Ldni;)V func_213106_a
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 dqy net/minecraft/client/gui/screen/WinGameScreen
 	a field_146580_a
 	b field_146576_f
@@ -54182,12 +54182,12 @@ dqy net/minecraft/client/gui/screen/WinGameScreen
 	w field_146579_r
 	x field_146578_s
 	a (IIF)V func_146575_b
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Ljava/lang/Integer;Ljava/lang/Integer;)V func_238665_a_
-	b ()V func_231160_c_
-	d ()V func_231023_e_
+	b ()V func_231160_c_ init
+	d ()V func_231023_e_ tick
 	i ()V func_146574_g
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dqz net/minecraft/client/gui/screen/StatsScreen
 	a field_146549_a
 	c field_146550_h
@@ -54198,7 +54198,7 @@ dqz net/minecraft/client/gui/screen/StatsScreen
 	t field_146543_v
 	a (I)I func_195224_b
 	a (Lacr;)Ljava/lang/String; func_238666_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IILbke;)V func_238667_a_
 	a (Ldni;)V func_213113_a
 	a (Ldnt;)V func_213110_a
@@ -54206,7 +54206,7 @@ dqz net/minecraft/client/gui/screen/StatsScreen
 	a (Ldqz;I)I func_238669_a_
 	a (Ldqz;Ldhl;IIII)V func_238670_a_
 	a (Ldqz;Ldhl;IILbke;)V func_238671_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Lacr;)Ljava/lang/String; func_238672_b_
 	b (Ldni;)V func_213114_b
 	b (Ldqz;)Lacv; func_238673_b_
@@ -54230,16 +54230,16 @@ dqz net/minecraft/client/gui/screen/StatsScreen
 	m (Ldqz;)Ldmt; access$1900
 	n (Ldqz;)Ldmt; access$2000
 	o (Ldqz;)Ldmt; func_238678_o_
-	ax_ ()Z func_231177_au__
+	ax_ ()Z func_231177_au__ isPauseScreen
 dqz$1 net/minecraft/client/gui/screen/StatsScreen$1
 dqz$a net/minecraft/client/gui/screen/StatsScreen$CustomStatsList
 	a field_148208_k
 	a (Lacr;)Ljava/lang/String; func_238679_a_
-	a (Ldhl;)V func_230433_a_
+	a (Ldhl;)V func_230433_a_ renderBackground
 dqz$a$a net/minecraft/client/gui/screen/StatsScreen$CustomStatsList$Entry
 	a field_214404_a
 	b field_214405_b
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 dqz$b net/minecraft/client/gui/screen/StatsScreen$StatsList
 	a field_195113_v
 	o field_195114_w
@@ -54251,31 +54251,31 @@ dqz$b net/minecraft/client/gui/screen/StatsScreen$StatsList
 	u field_148220_k
 	v field_195112_D
 	a (I)Lact; func_195108_d
-	a (II)V func_230938_a_
+	a (II)V func_230938_a_ clickedHeader
 	a (Lact;)V func_195107_a
 	a (Lbke;)Lmr; func_200208_a
-	a (Ldhl;)V func_230433_a_
-	a (Ldhl;II)V func_230447_a_
-	a (Ldhl;IILdhn;)V func_230448_a_
+	a (Ldhl;)V func_230433_a_ renderBackground
+	a (Ldhl;II)V func_230447_a_ renderDecorations
+	a (Ldhl;IILdhn;)V func_230448_a_ renderHeader
 	a (Ldhl;Lmr;II)V func_238680_a_
 	b (Lact;)I func_195105_b
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 dqz$b$a net/minecraft/client/gui/screen/StatsScreen$StatsList$Comparator
 	a field_198835_a
 	a (Lbke;Lbke;)I compare
 	compare (Ljava/lang/Object;Ljava/lang/Object;)I compare
 dqz$b$b net/minecraft/client/gui/screen/StatsScreen$StatsList$Entry
 	a field_214407_a
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;Lacr;IIZ)V func_238681_a_
 dqz$c net/minecraft/client/gui/screen/StatsScreen$MobStatsList
 	a field_148223_k
-	a (Ldhl;)V func_230433_a_
+	a (Ldhl;)V func_230433_a_ renderBackground
 dqz$c$a net/minecraft/client/gui/screen/StatsScreen$MobStatsList$Entry
 	a field_214410_a
 	b field_214411_b
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ljava/lang/String;I)Ljava/lang/String; func_214409_a
 	b (Ljava/lang/String;I)Ljava/lang/String; func_214408_b
 dra net/minecraft/client/gui/IProgressMeter
@@ -54379,20 +54379,20 @@ drg net/minecraft/client/gui/advancements/AdvancementsScreen
 	q field_191940_s
 	r field_191944_v
 	a ()V func_191930_a
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
-	a (III)Z func_231046_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
+	a (III)Z func_231046_a_ keyPressed
 	a (Ldhl;II)V func_238695_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Lw;)V func_191931_a
 	a (Lw;Ly;)V func_191933_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Lw;)V func_191928_b
 	c (Ldhl;IIII)V func_238696_c_
 	c (Lw;)V func_191932_c
 	d (Ldhl;IIII)V func_238697_d_
 	d (Lw;)V func_191929_d
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Lw;)V func_193982_e
 	f (Lw;)Ldre; func_191938_e
 	g (Lw;)Ldrc; func_191935_f
@@ -54402,9 +54402,9 @@ dri net/minecraft/client/gui/widget/list/KeyBindingList
 	a (Ldri;)Ldlx; access$100
 	b (Ldri;)Ldlx; func_214341_b
 	c (Ldri;)Ldlx; func_214336_c
-	d ()I func_230949_c_
+	d ()I func_230949_c_ getRowWidth
 	d (Ldri;)Ldlx; func_214337_d
-	e ()I func_230952_d_
+	e ()I func_230952_d_ getScrollbarPosition
 	e (Ldri;)Ldrj; func_238698_e_
 	f (Ldri;)I func_238699_f_
 	g (Ldri;)Ldlx; func_238700_g_
@@ -54416,9 +54416,9 @@ dri$a net/minecraft/client/gui/widget/list/KeyBindingList$CategoryEntry
 	a field_148287_a
 	b field_148285_b
 	c field_148286_c
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
-	c_ (Z)Z func_231049_c__
-	av_ ()Ljava/util/List; func_231039_at__
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
+	c_ (Z)Z func_231049_c__ changeFocus
+	av_ ()Ljava/util/List; func_231039_at__ children
 dri$b net/minecraft/client/gui/widget/list/KeyBindingList$Entry
 dri$c net/minecraft/client/gui/widget/list/KeyBindingList$KeyEntry
 	a field_148284_a
@@ -54426,33 +54426,33 @@ dri$c net/minecraft/client/gui/widget/list/KeyBindingList$KeyEntry
 	c field_148283_c
 	d field_148280_d
 	e field_148281_e
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldlu;Ldni;)V func_214387_a
 	b (Ldlu;Ldni;)V func_214386_b
-	c (DDI)Z func_231048_c_
-	av_ ()Ljava/util/List; func_231039_at__
+	c (DDI)Z func_231048_c_ mouseReleased
+	av_ ()Ljava/util/List; func_231039_at__ children
 dri$c$1 net/minecraft/client/gui/widget/list/KeyBindingList$KeyEntry$1
 	a field_194933_o
 	b field_194931_p
 	c field_238701_c_
 	d field_194932_q
-	c ()Lmx; func_230442_c_
+	c ()Lmx; func_230442_c_ getNarrationMessage
 dri$c$2 net/minecraft/client/gui/widget/list/KeyBindingList$KeyEntry$2
 	a field_194936_o
 	b field_238702_b_
 	c field_194935_q
-	c ()Lmx; func_230442_c_
+	c ()Lmx; func_230442_c_ getNarrationMessage
 drj net/minecraft/client/gui/screen/ControlsScreen
 	c field_146491_f
 	p field_152177_g
 	q field_146494_r
 	r field_146493_s
-	a (DDI)Z func_231044_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_213124_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_213125_b
 	c (Ldni;)V func_213126_c
 drl net/minecraft/client/gui/screen/GamemodeSelectionScreen
@@ -54465,18 +54465,18 @@ drl net/minecraft/client/gui/screen/GamemodeSelectionScreen
 	s field_238709_s_
 	t field_238710_t_
 	u field_238711_u_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Ldrl$a;)V func_238712_a_
 	a (Ldlx;Ljava/util/Optional;)V func_238713_a_
 	a (Ldrl$b;Ldrl$a;)V func_238714_a_
 	a (Ldrl;)Lehh; func_238715_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	i ()Luh; func_238716_g_
 	k ()Lbpy; func_241608_k_
 	l ()V func_238717_j_
 	m ()Z func_238718_l_
-	ax_ ()Z func_231177_au__
+	ax_ ()Z func_231177_au__ isPauseScreen
 drl$1 net/minecraft/client/gui/screen/GamemodeSelectionScreen$1
 	a field_238719_a_
 	b field_238720_b_
@@ -54508,10 +54508,10 @@ drl$b net/minecraft/client/gui/screen/GamemodeSelectionScreen$SelectorWidget
 	c field_238737_c_
 	a (Ldhl;Lelw;)V func_238738_a_
 	a (Ldrl$b;)Ldrl$a; func_238739_a_
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 	b (Ldhl;Lelw;)V func_238740_b_
 	e (Z)V func_238741_e_
-	g ()Z func_230449_g_
+	g ()Z func_230449_g_ isHovered
 drm net/minecraft/client/gui/screen/AbstractCommandBlockScreen
 	a field_195237_a
 	b field_195239_f
@@ -54520,28 +54520,28 @@ drm net/minecraft/client/gui/screen/AbstractCommandBlockScreen
 	q field_195242_i
 	r field_195238_s
 	s field_228184_g_
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
-	a (III)Z func_231046_a_
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (III)Z func_231046_a_ keyPressed
 	a (Lbpc;)V func_195235_a
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_214184_a
 	a (Ldrm;)Ldnl; func_228185_a_
 	a (Ljava/lang/String;)V func_214185_b
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_214186_b
 	c (Ldni;)V func_214187_c
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()Lbpc; func_195231_h
 	k ()I func_195236_i
 	l ()V func_195233_j
 	m ()V func_195234_k
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 drm$1 net/minecraft/client/gui/screen/AbstractCommandBlockScreen$1
 	a field_228186_a_
-	c ()Lmx; func_230442_c_
+	c ()Lmx; func_230442_c_ getNarrationMessage
 drn net/minecraft/client/gui/screen/inventory/ContainerScreen
 	a field_147001_a
 	b field_146999_f
@@ -54577,57 +54577,57 @@ drn net/minecraft/client/gui/screen/inventory/ContainerScreen
 	R field_146993_M
 	S field_146994_N
 	a (DD)Lbhw; func_195360_a
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
 	a (DDIII)Z func_195361_a
 	a (I)V func_241609_a_
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (IIIIDD)Z func_195359_a
 	a (Lbhw;DD)Z func_195362_a
 	a (Lbhw;IILbgq;)V func_184098_a
 	a (Lbki;IILjava/lang/String;)V func_146982_a
 	a (Ldhl;FII)V func_230450_a_
 	a (Ldhl;II)V func_230459_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Lbhw;)V func_238746_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (II)Z func_195363_d
 	b (Ldhl;II)V func_230451_b_
-	c (DDI)Z func_231048_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	c (DDI)Z func_231048_c_ mouseReleased
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()Lbgi; func_212873_a_
 	m ()V func_146980_g
-	at_ ()Z func_231178_ax__
-	ax_ ()Z func_231177_au__
+	at_ ()Z func_231178_ax__ shouldCloseOnEsc
+	ax_ ()Z func_231177_au__ isPauseScreen
 dro net/minecraft/client/gui/screen/inventory/AbstractFurnaceScreen
 	A field_214088_k
 	B field_214089_l
 	C field_214090_m
 	D field_214091_n
-	a (CI)Z func_231042_a_
-	a (DDI)Z func_231044_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (DDIII)Z func_195361_a
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Lbhw;IILbgq;)V func_184098_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_214087_a
-	b ()V func_231160_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	b ()V func_231160_c_ init
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	l ()Ldtn; func_194310_f
 	ay_ ()V func_192043_J_
 drp net/minecraft/client/gui/screen/inventory/AnvilScreen
 	A field_147093_u
 	B field_147091_w
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Lbgi;ILbki;)V func_71111_a
-	a (Ldlx;II)V func_231152_a_
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ljava/lang/String;)V func_214075_a
 	b (Ldhl;II)V func_230451_b_
 	b (Ldhl;IIF)V func_230452_b_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	k ()V func_230453_j_
 drq net/minecraft/client/gui/screen/inventory/BeaconScreen
 	A field_147025_v
@@ -54636,16 +54636,16 @@ drq net/minecraft/client/gui/screen/inventory/BeaconScreen
 	D field_214105_n
 	E field_214106_o
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldrq;)Ljava/util/List; func_214104_a
 	a (Ldrq;Laoe;)Laoe; func_214095_a
 	a (Ldrq;Z)Z func_214099_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldhl;II)V func_230451_b_
 	b (Ldrq;)Ljava/util/List; func_214101_b
 	b (Ldrq;Laoe;)Laoe; func_214100_b
 	c (Ldrq;)Laoe; func_214097_c
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldrq;)Laoe; func_214096_d
 	e (Ldrq;)Ldlx; access$600
 	f (Ldrq;)Ldlx; access$700
@@ -54663,25 +54663,25 @@ drq$1 net/minecraft/client/gui/screen/inventory/BeaconScreen$1
 	a (Lbgi;Lgi;)V func_71110_a
 drq$a net/minecraft/client/gui/screen/inventory/BeaconScreen$CancelButton
 	a field_146146_o
-	a (Ldhl;II)V func_230443_a_
-	b ()V func_230930_b_
+	a (Ldhl;II)V func_230443_a_ renderToolTip
+	b ()V func_230930_b_ onPress
 drq$b net/minecraft/client/gui/screen/inventory/BeaconScreen$ConfirmButton
 	a field_146147_o
-	a (Ldhl;II)V func_230443_a_
-	b ()V func_230930_b_
+	a (Ldhl;II)V func_230443_a_ renderToolTip
+	b ()V func_230930_b_ onPress
 drq$c net/minecraft/client/gui/screen/inventory/BeaconScreen$PowerButton
 	a field_146150_o
 	b field_184066_p
 	c field_212946_c
 	d field_212947_d
 	a (Ldhl;)V func_230454_a_
-	a (Ldhl;II)V func_230443_a_
-	b ()V func_230930_b_
+	a (Ldhl;II)V func_230443_a_ renderToolTip
+	b ()V func_230930_b_ onPress
 drq$d net/minecraft/client/gui/screen/inventory/BeaconScreen$Button
 	a field_146142_r
 	a ()Z func_146141_c
 	a (Ldhl;)V func_230454_a_
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 	e (Z)V func_146140_b
 drq$e net/minecraft/client/gui/screen/inventory/BeaconScreen$SpriteButton
 	a field_212948_a
@@ -54710,12 +54710,12 @@ drs net/minecraft/client/gui/screen/EditBookScreen
 	D field_214249_r
 	E field_214250_s
 	F field_238747_F_
-	a (CI)Z func_231042_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
 	a (I)V func_238755_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Ldrs$c;Z)V func_238756_a_
 	a (Ldni;)V func_214205_a_
 	a (Ldrs$c;)Ldrs$c; func_238758_a_
@@ -54725,7 +54725,7 @@ drs net/minecraft/client/gui/screen/EditBookScreen
 	a (Lorg/apache/commons/lang3/mutable/MutableInt;Ljava/lang/String;Lorg/apache/commons/lang3/mutable/MutableBoolean;Lit/unimi/dsi/fastutil/ints/IntList;Ljava/util/List;Lnb;II)V func_238762_a_
 	a ([II)I func_238763_a_
 	a ([Lece;)V func_238764_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)V func_238765_b_
 	b (Ldni;)V func_214208_b_
 	b (Ldrs$c;)Ldrs$c; func_238767_b_
@@ -54734,11 +54734,11 @@ drs net/minecraft/client/gui/screen/EditBookScreen
 	c (III)Z func_214230_b
 	c (Ldni;)V func_214212_c_
 	c (Z)V func_214198_a
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (III)Z func_214196_c
 	d (Ldni;)V func_214195_d_
 	d (Ljava/lang/String;)I func_214225_l
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_214204_a
 	e (Ljava/lang/String;)Z func_238771_e_
 	f (Ldni;)V func_214201_b
@@ -54803,16 +54803,16 @@ drt net/minecraft/client/gui/screen/ReadBookScreen
 	t field_214173_h
 	u field_214174_i
 	a (DD)Lnb; func_238805_a_
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (I)Z func_214160_a
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_214158_a
 	a (Ldrt$a;)V func_214155_a
 	a (Ljava/lang/String;)I func_214156_a
 	a (Lle;)Ljava/util/List; func_214157_a
-	a (Lnb;)Z func_230455_a_
-	b ()V func_231160_c_
+	a (Lnb;)Z func_230455_a_ handleComponentClicked
+	b ()V func_231160_c_ init
 	b (I)Z func_214153_b
 	b (Ldni;)V func_214159_b
 	c (Ldni;)V func_214161_c
@@ -54844,13 +54844,13 @@ dru net/minecraft/client/gui/screen/inventory/BrewingStandScreen
 	A field_147014_u
 	B field_184857_v
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
-	b ()V func_231160_c_
+	a (Ldhl;IIF)V func_230430_a_ render
+	b ()V func_231160_c_ init
 drv net/minecraft/client/gui/screen/inventory/CartographyTableScreen
 	A field_214109_k
 	a (Lczv;IIF)V func_214108_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Lczv;ZZZZ)V func_238807_a_
 drw net/minecraft/client/gui/screen/CommandBlockScreen
 	s field_184078_g
@@ -54861,9 +54861,9 @@ drw net/minecraft/client/gui/screen/CommandBlockScreen
 	x field_184084_y
 	y field_184085_z
 	a (Lbpc;)V func_195235_a
-	a (Ldlx;II)V func_231152_a_
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_214189_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_214190_b
 	c (Ldni;)V func_214191_c
 	i ()Lbpc; func_195231_h
@@ -54879,22 +54879,22 @@ drx net/minecraft/client/gui/screen/inventory/ChestScreen
 	A field_147017_u
 	B field_147018_x
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 dry net/minecraft/client/gui/screen/inventory/CraftingScreen
 	A field_147019_u
 	B field_201559_w
 	C field_192050_x
 	D field_193112_y
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (DDIII)Z func_195361_a
 	a (IIIIDD)Z func_195359_a
 	a (Lbhw;IILbgq;)V func_184098_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_214076_a
-	b ()V func_231160_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	b ()V func_231160_c_ init
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	l ()Ldtn; func_194310_f
 	ay_ ()V func_192043_J_
 drz net/minecraft/client/gui/screen/inventory/CreativeCraftingListener
@@ -54915,13 +54915,13 @@ dsa net/minecraft/client/gui/screen/inventory/CreativeScreen
 	K field_195377_F
 	L field_199506_G
 	M field_214085_w
-	a (CI)Z func_231042_a_
+	a (CI)Z func_231042_a_ charTyped
 	a (DD)Z func_195376_a
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
 	a (DDIII)Z func_195361_a
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Ladg;Luh;)V func_214082_a
 	a (Lbhw;)Z func_208018_a
 	a (Lbhw;IILbgq;)V func_184098_a
@@ -54929,21 +54929,21 @@ dsa net/minecraft/client/gui/screen/inventory/CreativeScreen
 	a (Lbiy;DD)Z func_195375_a
 	a (Lbke;Ljava/util/List;Luh;Ladf;)V func_214083_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;Lbiy;)V func_238808_a_
 	a (Ldhl;Lbiy;II)Z func_238809_a_
-	a (Ldhl;Lbki;II)V func_230457_a_
-	a (Ldlx;II)V func_231152_a_
+	a (Ldhl;Lbki;II)V func_230457_a_ renderTooltip
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldlx;IZZ)V func_192044_a
 	a (Ljava/lang/String;)V func_214080_a
 	a (Ljava/lang/String;Ljava/lang/String;Luh;)Z func_214081_a
 	a (Ljava/lang/String;Luh;)Z func_214084_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (III)Z func_223281_a_
 	b (Ldhl;II)V func_230451_b_
-	c (DDI)Z func_231048_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	c (DDI)Z func_231048_c_ mouseReleased
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	k ()V func_175378_g
 	l ()I func_147056_g
 	m ()Lanm; access$000
@@ -54977,13 +54977,13 @@ dsa$c net/minecraft/client/gui/screen/inventory/CreativeScreen$CreativeSlot
 dsb net/minecraft/client/gui/screen/inventory/DispenserScreen
 	A field_147088_v
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
-	b ()V func_231160_c_
+	a (Ldhl;IIF)V func_230430_a_ render
+	b ()V func_231160_c_ init
 dsc net/minecraft/client/gui/DisplayEffectsScreen
 	A field_147045_u
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IILjava/lang/Iterable;)V func_238810_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldhl;)V func_238811_b_
 	b (Ldhl;IILjava/lang/Iterable;)V func_238812_b_
 	c (Ldhl;IILjava/lang/Iterable;)V func_238813_c_
@@ -55010,28 +55010,28 @@ dse net/minecraft/client/gui/screen/EnchantmentScreen
 	J field_147072_E
 	K field_147074_F
 	L field_147077_B
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
-	d ()V func_231023_e_
+	a (Ldhl;IIF)V func_230430_a_ render
+	d ()V func_231023_e_ tick
 	k ()V func_147068_g
 dsf net/minecraft/client/gui/screen/inventory/FurnaceScreen
 	B field_147087_u
 dsg net/minecraft/client/gui/screen/GrindstoneScreen
 	A field_214110_k
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 dsh net/minecraft/client/gui/screen/HopperScreen
 	A field_147085_u
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 dsi net/minecraft/client/gui/screen/inventory/HorseInventoryScreen
 	A field_147031_u
 	B field_147034_x
 	C field_147033_y
 	D field_147032_z
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 dsj net/minecraft/client/gui/screen/inventory/InventoryScreen
 	B field_201555_w
 	C field_147048_u
@@ -55040,20 +55040,20 @@ dsj net/minecraft/client/gui/screen/inventory/InventoryScreen
 	F field_212353_B
 	G field_192046_B
 	H field_194031_B
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (DDIII)Z func_195361_a
 	a (IIIFFLaoy;)V func_228187_a_
 	a (IIIIDD)Z func_195359_a
 	a (Lbhw;IILbgq;)V func_184098_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_214086_a
 	a (Legm;Laoy;Ldhl;Lebz$a;)V func_241611_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldhl;II)V func_230451_b_
-	c (DDI)Z func_231048_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	c (DDI)Z func_231048_c_ mouseReleased
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	l ()Ldtn; func_194310_f
 	ay_ ()V func_192043_J_
 dsk net/minecraft/client/gui/screen/inventory/AbstractRepairScreen
@@ -55062,10 +55062,10 @@ dsk net/minecraft/client/gui/screen/inventory/AbstractRepairScreen
 	a (Lbgi;ILbki;)V func_71111_a
 	a (Lbgi;Lgi;)V func_71110_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
-	b ()V func_231160_c_
+	a (Ldhl;IIF)V func_230430_a_ render
+	b ()V func_231160_c_ init
 	b (Ldhl;IIF)V func_230452_b_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	k ()V func_230453_j_
 dsl net/minecraft/client/gui/screen/JigsawScreen
 	a field_214259_a
@@ -55078,22 +55078,22 @@ dsl net/minecraft/client/gui/screen/JigsawScreen
 	t field_238823_t_
 	u field_214263_e
 	v field_238824_v_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_238825_a_
 	a (Ldsl;)I func_238826_a_
 	a (Ldsl;I)I func_238827_a_
 	a (Ljava/lang/String;)V func_214254_b
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_238828_b_
 	b (Ldsl;)Z func_238829_b_
 	b (Ljava/lang/String;)V func_238830_b_
 	c (Ldni;)V func_238831_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_238832_d_
 	d (Ljava/lang/String;)V func_238833_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_238834_e_
 	i ()V func_214256_b
 	k ()V func_214257_c
@@ -55101,25 +55101,25 @@ dsl net/minecraft/client/gui/screen/JigsawScreen
 	m ()V func_238835_m_
 	n ()V func_214253_a
 	u ()Lmr; func_238836_u_
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dsl$1 net/minecraft/client/gui/screen/JigsawScreen$1
 	a field_238837_a_
 	a ()V func_230972_a_
 	b ()V func_230979_b_
 dsl$2 net/minecraft/client/gui/screen/JigsawScreen$2
 	a field_238838_a_
-	i ()Lmr; func_230458_i_
+	i ()Lmr; func_230458_i_ getMessage
 dsm net/minecraft/client/gui/screen/LecternScreen
 	c field_214182_c
 	p field_214183_d
 	a (Ldni;)V func_214178_a
 	a (Ldsm;)V func_214177_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (I)Z func_214153_b
 	b (Ldni;)V func_214181_b
 	b (Ldsm;)V func_214180_b
 	c (I)V func_214179_c
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	i ()Lbgi; func_212873_a_
 	k ()V func_214162_b
 	m ()V func_214165_d
@@ -55127,8 +55127,8 @@ dsm net/minecraft/client/gui/screen/LecternScreen
 	u ()Lbhh; func_212873_a_
 	v ()V func_214175_g
 	w ()V func_214176_h
-	au_ ()V func_231175_as__
-	ax_ ()Z func_231177_au__
+	au_ ()V func_231175_as__ onClose
+	ax_ ()Z func_231177_au__ isPauseScreen
 dsm$1 net/minecraft/client/gui/screen/LecternScreen$1
 	a field_213130_a
 	a (Lbgi;II)V func_71112_a
@@ -55148,12 +55148,12 @@ dsn net/minecraft/client/gui/screen/LoomScreen
 	K field_214126_x
 	L field_214127_y
 	M field_214128_z
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
 	a (DDIII)Z func_195361_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	c (III)V func_228190_b_
 	k ()V func_214111_b
 dso net/minecraft/client/gui/IHasContainer
@@ -55164,12 +55164,12 @@ dsp net/minecraft/client/gui/screen/inventory/MerchantScreen
 	C field_214138_m
 	D field_214139_n
 	E field_214140_o
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
 	a (I)Z func_214135_a
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IILboz;)V func_238839_a_
 	a (Ldhl;IILbpa;)V func_238840_a_
 	a (Ldhl;Lbki;Lbki;II)V func_238841_a_
@@ -55177,7 +55177,7 @@ dsp net/minecraft/client/gui/screen/inventory/MerchantScreen
 	a (Ldni;)V func_214132_a
 	a (Ldsp;)I access$000
 	a (Ldsp;Ldhl;Lbki;II)V func_238843_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldhl;II)V func_230451_b_
 	b (Ldsp;Ldhl;Lbki;II)V func_238844_b_
 	c (Ldsp;Ldhl;Lbki;II)V func_238845_c_
@@ -55186,22 +55186,22 @@ dsp$a net/minecraft/client/gui/screen/inventory/MerchantScreen$TradeButton
 	a field_212938_a
 	b field_212939_b
 	a ()I func_212937_a
-	a (Ldhl;II)V func_230443_a_
+	a (Ldhl;II)V func_230443_a_ renderToolTip
 dsq net/minecraft/client/gui/screen/EditMinecartCommandBlockScreen
 	s field_184093_g
 	a (Lbpc;)V func_195235_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	i ()Lbpc; func_195231_h
 	k ()I func_195236_i
 dsr net/minecraft/client/gui/widget/button/ChangePageButton
 	a field_212940_a
 	b field_212941_b
-	a (Lepn;)V func_230988_a_
-	b (Ldhl;IIF)V func_230431_b_
+	a (Lepn;)V func_230988_a_ playDownSound
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dss net/minecraft/client/gui/screen/inventory/ShulkerBoxScreen
 	A field_190778_u
 	a (Ldhl;FII)V func_230450_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 dst net/minecraft/client/gui/screen/EditSignScreen
 	a field_228191_a_
 	b field_146848_f
@@ -55209,19 +55209,19 @@ dst net/minecraft/client/gui/screen/EditSignScreen
 	p field_146851_h
 	q field_214267_d
 	r field_238846_r_
-	a (CI)Z func_231042_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_238847_a_
 	a (Ljava/lang/String;)Z func_238848_a_
 	a ([Ljava/lang/String;)V func_238849_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ljava/lang/String;)V func_238850_b_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
 	i ()V func_195269_h
 	k ()Ljava/lang/String; func_238851_j_
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dsu net/minecraft/client/gui/screen/inventory/SmithingTableScreen
 	A field_238852_A_
 	b (Ldhl;II)V func_230451_b_
@@ -55233,12 +55233,12 @@ dsw net/minecraft/client/gui/screen/inventory/StonecutterScreen
 	C field_214148_m
 	D field_214149_n
 	E field_214150_o
-	a (DDD)Z func_231043_a_
-	a (DDI)Z func_231044_a_
-	a (DDIDD)Z func_231045_a_
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (DDIDD)Z func_231045_a_ mouseDragged
 	a (Ldhl;FII)V func_230450_a_
 	a (Ldhl;II)V func_230459_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	b (Ldhl;IIIII)V func_238853_b_
 	c (III)V func_214142_b
 	k ()I func_214144_b
@@ -55277,21 +55277,21 @@ dsx net/minecraft/client/gui/screen/EditStructureScreen
 	P field_189841_Q
 	Q field_189842_R
 	R field_189844_T
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Lcel$a;)Z func_210143_a
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_214271_a
 	a (Ldsx;Ljava/lang/String;CI)Z func_214279_a
 	a (Ljava/lang/String;)J func_189821_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_214272_b
 	b (Ljava/lang/String;)F func_189819_b
 	c (Ldni;)V func_214273_c
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_214268_d
 	d (Ljava/lang/String;)I func_189817_c
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_214270_e
 	f (Ldni;)V func_214269_f
 	g (Ldni;)V func_214281_g
@@ -55310,11 +55310,11 @@ dsx net/minecraft/client/gui/screen/EditStructureScreen
 	u ()V func_189816_h
 	v ()V func_189824_i
 	w ()V func_189823_j
-	au_ ()V func_231175_as__
-	ax_ ()Z func_231177_au__
+	au_ ()V func_231175_as__ onClose
+	ax_ ()Z func_231177_au__ isPauseScreen
 dsx$1 net/minecraft/client/gui/screen/EditStructureScreen$1
 	a field_194960_o
-	a (CI)Z func_231042_a_
+	a (CI)Z func_231042_a_ charTyped
 dsx$2 net/minecraft/client/gui/screen/EditStructureScreen$2
 	a field_217096_a
 	b field_217097_b
@@ -55333,20 +55333,20 @@ dta net/minecraft/client/gui/screen/MultiplayerScreen
 	w field_146799_A
 	x field_146800_B
 	y field_146801_C
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_214289_a
 	a (Ldtc$a;)V func_214287_a
 	a (Ldys;)V func_146791_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_214291_b
 	b (Ljava/util/List;)V func_238854_b_
 	c (Ldni;)V func_214294_c
 	c (Z)V func_214285_a
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_214283_d
 	d (Z)V func_214292_b
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_214288_e
 	e (Z)V func_214284_c
 	f (Ldni;)V func_214286_f
@@ -55365,11 +55365,11 @@ dtb net/minecraft/client/gui/screen/MultiplayerWarningScreen
 	q field_238858_q_
 	r field_230162_g_
 	s field_230163_h_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_230164_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_230165_b_
-	as_ ()Ljava/lang/String; func_231167_h_
+	as_ ()Ljava/lang/String; func_231167_h_ getNarrationMessage
 dtc net/minecraft/client/gui/screen/ServerSelectionList
 	a field_214357_a
 	o field_214358_b
@@ -55379,19 +55379,19 @@ dtc net/minecraft/client/gui/screen/ServerSelectionList
 	s field_148198_l
 	t field_148196_n
 	u field_148199_m
-	a (III)Z func_231046_a_
-	a (Ldne$a;)V func_241215_a_
-	a (Ldne$b;)V func_241219_a_
-	a (Ldtc$a;)V func_241215_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldne$a;)V func_241215_a_ setSelected
+	a (Ldne$b;)V func_241219_a_ moveSelection
+	a (Ldtc$a;)V func_241215_a_ setSelected
 	a (Ldtc;)I func_228193_a_
 	a (Ldtc;I)I func_228194_a_
 	a (Ldtc;Ldne$a;)V func_228195_a_
 	a (Ldyt;)V func_148195_a
 	a (Ljava/util/List;)V func_148194_a
-	b ()Z func_230971_aw__
+	b ()Z func_230971_aw__ isFocused
 	b (Ldtc$a;)Z func_241612_b_
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 	f ()Ljava/util/concurrent/ThreadPoolExecutor; func_214352_a
 	g ()Luh; func_214355_b
 	s ()Luh; func_214351_c
@@ -55400,15 +55400,15 @@ dtc net/minecraft/client/gui/screen/ServerSelectionList
 dtc$a net/minecraft/client/gui/screen/ServerSelectionList$Entry
 dtc$b net/minecraft/client/gui/screen/ServerSelectionList$LanScanEntry
 	a field_148288_a
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 dtc$c net/minecraft/client/gui/screen/ServerSelectionList$LanDetectedEntry
 	a field_148293_a
 	b field_148291_b
 	c field_148292_c
 	d field_148290_d
 	a ()Lepa; func_189995_a
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 dtc$d net/minecraft/client/gui/screen/ServerSelectionList$NormalEntry
 	a field_214413_a
 	b field_148303_c
@@ -55419,10 +55419,10 @@ dtc$d net/minecraft/client/gui/screen/ServerSelectionList$NormalEntry
 	g field_148305_h
 	h field_148298_f
 	a ()V func_241613_a_
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (II)V func_228196_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldhl;IILuh;)V func_238859_a_
 	a (Ldtc$d;)Ldys; func_214412_a
 	a (Ljava/lang/String;)Z func_241614_a_
@@ -55508,7 +55508,7 @@ dtg net/minecraft/client/gui/screen/PackScreen
 	t field_238892_v_
 	u field_241817_w_
 	v field_238894_x_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldlx;Ljava/util/List;Ljava/nio/file/Path;)V func_238895_a_
 	a (Ldni;)V func_238896_a_
 	a (Ldni;Ldhl;II)V func_238897_a_
@@ -55518,22 +55518,22 @@ dtg net/minecraft/client/gui/screen/PackScreen
 	a (Ljava/nio/file/Path;Lorg/apache/commons/lang3/mutable/MutableBoolean;Ljava/nio/file/Path;)V func_238901_a_
 	a (Ljava/util/List;)V func_230476_a_
 	a (Ljava/util/List;Z)V func_238902_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_238903_b_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	i ()V func_238904_g_
 	k ()V func_238906_l_
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dth net/minecraft/client/gui/widget/list/ResourcePackList
 	a field_214367_b
 	o field_214368_c
 	p field_214369_d
 	q field_214370_e
-	a (Ldhl;IILdhn;)V func_230448_a_
+	a (Ldhl;IILdhn;)V func_230448_a_ renderHeader
 	a (Ldth;)I func_238911_a_
 	a (Ldth;I)I func_238912_a_
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 	f ()Luh; func_238913_e_
 	g ()Lmr; func_238914_f_
 	s ()Lmr; func_238915_q_
@@ -55543,8 +55543,8 @@ dth$a net/minecraft/client/gui/widget/list/ResourcePackList$ResourcePackEntry
 	c field_214430_c
 	d field_214431_d
 	a ()Z func_238920_a_
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Z)V func_238921_a_
 dtj net/minecraft/client/gui/recipebook/AbstractRecipeBookGui
 	l field_212964_i
@@ -55606,19 +55606,19 @@ dtm net/minecraft/client/gui/recipebook/RecipeOverlayGui
 	l field_193974_m
 	m field_201704_n
 	a ()Ldtr; func_193971_a
-	a (DDI)Z func_231044_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (DDI)Z func_231044_a_ mouseClicked
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldlx;Ldtr;IIIIF)V func_201703_a
 	a (Ldtm;)Ldlx; access$200
 	a (Z)V func_192999_a
 	b ()Lbmu; func_193967_b
-	b (DD)Z func_231047_b_
+	b (DD)Z func_231047_b_ isMouseOver
 	b (Ldtm;)Z access$300
 	c ()Z func_191839_a
 	c (Ldhl;IIIIII)V func_238923_c_
 	c (Ldtm;)F access$400
 	d ()Luh; access$100
-	c_ (Z)Z func_231049_c__
+	c_ (Z)Z func_231049_c__ changeFocus
 dtm$a net/minecraft/client/gui/recipebook/RecipeOverlayGui$RecipeButtonWidget
 	a field_201506_o
 	b field_193926_o
@@ -55627,7 +55627,7 @@ dtm$a net/minecraft/client/gui/recipebook/RecipeOverlayGui$RecipeButtonWidget
 	a (Lbmu;)V func_201505_a
 	a (Ldtm$a;)Lbmu; access$000
 	a (Ljava/util/Iterator;IIII)V func_201500_a
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dtm$a$a net/minecraft/client/gui/recipebook/RecipeOverlayGui$RecipeButtonWidget$Child
 	a field_201705_a
 	b field_201706_b
@@ -55656,14 +55656,14 @@ dtn net/minecraft/client/gui/recipebook/RecipeBookGui
 	t field_193966_v
 	u field_199738_u
 	a ()Z func_201521_f
-	a (CI)Z func_231042_a_
-	a (DDI)Z func_231044_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (DDIIIII)Z func_195604_a
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (IILdlx;ZLbhp;)V func_201520_a
 	a (Lbhw;)V func_191874_a
 	a (Lbmu;Ljava/util/List;)V func_193951_a
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldhl;IIZF)V func_230477_a_
 	a (Ldtp;)Z func_209505_a
 	a (Ldtr;)Z func_193958_a
@@ -55674,7 +55674,7 @@ dtn net/minecraft/client/gui/recipebook/RecipeBookGui
 	a (Z)V func_193003_g
 	a (ZII)I func_193011_a
 	b ()V func_193949_f
-	b (DD)Z func_231047_b_
+	b (DD)Z func_231047_b_ isMouseOver
 	b (III)Z func_223281_a_
 	b (Ldtr;)Z func_193953_b
 	c ()Z func_191878_b
@@ -55694,7 +55694,7 @@ dtn net/minecraft/client/gui/recipebook/RecipeBookGui
 	k ()V func_193957_d
 	l ()V func_193948_e
 	m ()V func_193956_j
-	c_ (Z)Z func_231049_c__
+	c_ (Z)Z func_231049_c__ changeFocus
 dto net/minecraft/client/gui/recipebook/RecipeBookPage
 	a field_193743_h
 	b field_194201_b
@@ -55730,7 +55730,7 @@ dtp net/minecraft/client/gui/recipebook/RecipeTabToggleWidget
 	a (Ldlx;)V func_193918_a
 	a (Lehh;)V func_193920_a
 	b ()Ldme; func_201503_d
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 dtq net/minecraft/client/gui/recipebook/RecipeWidget
 	a field_191780_o
 	b field_203401_p
@@ -55740,14 +55740,14 @@ dtq net/minecraft/client/gui/recipebook/RecipeWidget
 	s field_191778_t
 	t field_193932_t
 	a ()Ldtr; func_191771_c
-	a (I)Z func_230987_a_
+	a (I)Z func_230987_a_ isValidClickButton
 	a (II)V func_191770_c
 	a (Ldqs;)Ljava/util/List; func_191772_a
 	a (Ldtr;Ldto;)V func_203400_a
 	b ()Z func_193929_d
-	b (Ldhl;IIF)V func_230431_b_
+	b (Ldhl;IIF)V func_230431_b_ renderButton
 	d ()Lbmu; func_193760_e
-	h ()I func_230998_h_
+	h ()I func_230998_h_ getWidth
 	k ()Ljava/util/List; func_193927_f
 dtr net/minecraft/client/gui/recipebook/RecipeList
 	a field_192713_b
@@ -55812,13 +55812,13 @@ dty net/minecraft/client/gui/screen/CreateWorldScreen
 	J field_146328_H
 	K field_146330_J
 	L field_238932_M_
-	a (III)Z func_231046_a_
+	a (III)Z func_231046_a_ keyPressed
 	a (Laar;)V func_241621_a_
 	a (Lbpn;)V func_241622_a_
 	a (Lbpn;Luw;Ljava/lang/Throwable;)Ljava/lang/Object; func_241623_a_
 	a (Lbpx;)V func_238941_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldng;)Ldng; func_230480_a_
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldng;)Ldng; func_230480_a_ addButton
 	a (Ldni;)V func_214317_a
 	a (Ldty$b;)V func_228200_a_
 	a (Ldty;)Ljava/lang/String; func_228201_a_
@@ -55830,7 +55830,7 @@ dty net/minecraft/client/gui/screen/CreateWorldScreen
 	a (Ljava/util/List;Ljava/lang/String;)Z func_241626_a_
 	a (Ljava/util/Optional;)V func_238946_a_
 	a (Lorg/apache/commons/lang3/mutable/MutableObject;Ljava/nio/file/Path;Ljava/nio/file/Path;)V func_238947_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_214318_b
 	b (Ldty;)Ldty$b; func_228202_b_
 	b (Ljava/nio/file/Path;)V func_238948_b_
@@ -55838,12 +55838,12 @@ dty net/minecraft/client/gui/screen/CreateWorldScreen
 	c (Ldni;)V func_214321_c
 	c (Ldty;)Lmr; func_238950_c_
 	c (Z)V func_146316_a
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_214312_d
-	d (Ldof;)Ldof; func_230481_d_
+	d (Ldof;)Ldof; func_230481_d_ addListener
 	d (Ldty;)Lmr; func_238951_d_
 	d (Z)V func_241630_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_214320_g
 	e (Ldty;)Land; func_238953_e_
 	f (Ldni;)V func_214322_h
@@ -55861,21 +55861,21 @@ dty net/minecraft/client/gui/screen/CreateWorldScreen
 	x ()Z func_238960_x_
 	y ()V func_241631_y_
 	z ()V func_241632_z_
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dty$1 net/minecraft/client/gui/screen/CreateWorldScreen$1
 	a field_228210_a_
-	c ()Lmx; func_230442_c_
+	c ()Lmx; func_230442_c_ getNarrationMessage
 dty$2 net/minecraft/client/gui/screen/CreateWorldScreen$2
 	a field_228211_a_
-	c ()Lmx; func_230442_c_
-	i ()Lmr; func_230458_i_
+	c ()Lmx; func_230442_c_ getNarrationMessage
+	i ()Lmr; func_230458_i_ getMessage
 dty$3 net/minecraft/client/gui/screen/CreateWorldScreen$3
 	a field_228212_a_
-	i ()Lmr; func_230458_i_
+	i ()Lmr; func_230458_i_ getMessage
 dty$4 net/minecraft/client/gui/screen/CreateWorldScreen$4
 	a field_228213_a_
-	c ()Lmx; func_230442_c_
-	i ()Lmr; func_230458_i_
+	c ()Lmx; func_230442_c_ getNarrationMessage
+	i ()Lmr; func_230458_i_ getMessage
 dty$5 net/minecraft/client/gui/screen/CreateWorldScreen$5
 	a field_238963_a_
 dty$a net/minecraft/client/gui/screen/CreateWorldScreen$DatapackException
@@ -55898,13 +55898,13 @@ dtz net/minecraft/client/gui/screen/EditGamerulesScreen
 	p field_238968_p_
 	q field_238969_q_
 	r field_238970_r_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_238971_a_
 	a (Ldtz$f;)V func_238972_a_
 	a (Ldtz;)Ldlx; func_238973_a_
 	a (Ldtz;Ldtz$f;)V func_241633_a_
 	a (Ldtz;Ljava/util/List;)V func_241634_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_238976_b_
 	b (Ldtz$f;)V func_238977_b_
 	b (Ldtz;)Ldlx; func_238978_b_
@@ -55912,18 +55912,18 @@ dtz net/minecraft/client/gui/screen/EditGamerulesScreen
 	b (Ljava/util/List;)V func_238980_b_
 	c (Ldtz;)Ldlx; func_238981_c_
 	d (Ldtz;)Ldlx; func_241636_d_
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldtz;)Ldlx; func_241637_e_
 	f (Ldtz;)Ldlx; func_241638_f_
 	g (Ldtz;)Ldlx; func_241639_g_
 	h (Ldtz;)Ldmt; func_241640_h_
 	i ()V func_238984_g_
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dtz$a net/minecraft/client/gui/screen/EditGamerulesScreen$BooleanEntry
 	a field_238985_a_
 	e field_238986_c_
 	a (Lbpx$a;Ldni;)V func_238988_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Ldtz$a;Lmr;Z)Lmx; func_241642_a_
 	a (Lmr;Z)Lmx; func_238989_a_
 dtz$a$1 net/minecraft/client/gui/screen/EditGamerulesScreen$BooleanEntry$1
@@ -55932,12 +55932,12 @@ dtz$a$1 net/minecraft/client/gui/screen/EditGamerulesScreen$BooleanEntry$1
 	c field_241645_c_
 	d field_238991_b_
 	e field_238992_c_
-	c ()Lmx; func_230442_c_
+	c ()Lmx; func_230442_c_ getNarrationMessage
 dtz$b net/minecraft/client/gui/screen/EditGamerulesScreen$NameEntry
 	a field_238993_a_
 	b field_238994_c_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
-	av_ ()Ljava/util/List; func_231039_at__
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
+	av_ ()Ljava/util/List; func_231039_at__ children
 dtz$c net/minecraft/client/gui/screen/EditGamerulesScreen$IRuleEntry
 	create (Lmr;Ljava/util/List;Ljava/lang/String;Lbpx$g;)Ldtz$f; create
 dtz$d net/minecraft/client/gui/screen/EditGamerulesScreen$ValueEntry
@@ -55945,19 +55945,19 @@ dtz$d net/minecraft/client/gui/screen/EditGamerulesScreen$ValueEntry
 	b field_241647_b_
 	c field_241648_c_
 	a (Ldhl;II)V func_241649_a_
-	av_ ()Ljava/util/List; func_231039_at__
+	av_ ()Ljava/util/List; func_231039_at__ children
 dtz$e net/minecraft/client/gui/screen/EditGamerulesScreen$IntegerEntry
 	a field_238995_a_
 	e field_238997_d_
 	a (Lbpx$d;Ljava/lang/String;)V func_238999_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 dtz$f net/minecraft/client/gui/screen/EditGamerulesScreen$Gamerule
 	a field_239000_a_
 	d field_239001_b_
 	a (Ldtz$f;)Ljava/util/List; func_241650_a_
 dtz$g net/minecraft/client/gui/screen/EditGamerulesScreen$GamerulesList
 	a field_239003_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ljava/util/Map$Entry;)V func_239004_a_
 	b (Ljava/util/Map$Entry;)V func_239005_b_
 dtz$g$1 net/minecraft/client/gui/screen/EditGamerulesScreen$GamerulesList$1
@@ -55982,36 +55982,36 @@ dua net/minecraft/client/gui/screen/EditWorldScreen
 	a (Lcom/mojang/serialization/DataResult$PartialResult;)V func_239018_a_
 	a (Ldae$a;)Z func_239019_a_
 	a (Ldae;Ljava/lang/String;)V func_241651_a_
-	a (Ldhl;IIF)V func_230430_a_
-	a (Ldlx;II)V func_231152_a_
+	a (Ldhl;IIF)V func_230430_a_ render
+	a (Ldlx;II)V func_231152_a_ resize
 	a (Ldni;)V func_214306_a_
 	a (Ljava/lang/String;)V func_214301_a_
 	a (ZZ)V func_214305_a
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_214308_b_
 	c (Ldni;)V func_239023_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_214310_c
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_214302_d
 	f (Ldni;)V func_214304_e
 	g (Ldni;)V func_214303_f
 	h (Ldni;)V func_214309_g
 	i ()V func_195317_h
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dub net/minecraft/client/gui/screen/OptimizeWorldScreen
 	a field_239024_a_
 	b field_212348_a
 	c field_214332_b
 	p field_212203_f
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldlx;Lit/unimi/dsi/fastutil/booleans/BooleanConsumer;Lcom/mojang/datafixers/DataFixer;Ldae$a;Z)Ldub; func_239025_a_
 	a (Ldni;)V func_214331_a
 	a (Lit/unimi/dsi/fastutil/objects/Object2IntOpenCustomHashMap;)V func_212346_a
-	b ()V func_231160_c_
-	d ()V func_231023_e_
-	e ()V func_231164_f_
-	au_ ()V func_231175_as__
+	b ()V func_231160_c_ init
+	d ()V func_231023_e_ tick
+	e ()V func_231164_f_ removed
+	au_ ()V func_231175_as__ onClose
 duc net/minecraft/client/gui/screen/WorldSelectionScreen
 	a field_184864_a
 	b field_212352_g
@@ -56021,25 +56021,25 @@ duc net/minecraft/client/gui/screen/WorldSelectionScreen
 	r field_146630_A
 	s field_184865_t
 	t field_184866_u
-	a (CI)Z func_231042_a_
-	a (DDD)Z func_231043_a_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (CI)Z func_231042_a_ charTyped
+	a (DDD)Z func_231043_a_ mouseScrolled
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldni;)V func_214327_a
 	a (Ljava/lang/String;)V func_214329_b
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldni;)V func_214328_b
 	b (Ljava/lang/String;)Ljava/lang/String; func_212351_b
 	b (Ljava/util/List;)V func_239026_b_
 	c (Ldni;)V func_214330_c
 	c (Z)V func_214324_a
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	d (Ldni;)V func_214323_d
-	e ()V func_231164_f_
+	e ()V func_231164_f_ removed
 	e (Ldni;)V func_214326_e
 	f (Ldni;)V func_214325_f
 	i ()Ljava/lang/String; func_212349_h
-	au_ ()V func_231175_as__
+	au_ ()V func_231175_as__ onClose
 dud net/minecraft/client/gui/screen/WorldOptionsScreen
 	a field_239027_a_
 	b field_239028_b_
@@ -56058,7 +56058,7 @@ dud net/minecraft/client/gui/screen/WorldOptionsScreen
 	o field_239041_o_
 	a ()Z func_239042_a_
 	a (Lcix;)V func_239043_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldlx;Ldty;Ldni;)V func_239044_a_
 	a (Ldlx;Ldty;Lgm$a;Lcix;Z)V func_239045_a_
 	a (Ldlx;Ldty;Lgm$a;Lcom/mojang/serialization/Lifecycle;Lcix;)V func_239046_a_
@@ -56076,20 +56076,20 @@ dud net/minecraft/client/gui/screen/WorldOptionsScreen
 	b (Ljava/lang/String;)V func_239058_b_
 	b (Z)V func_239059_b_
 	c ()Lmr; func_239060_c_
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	e ()Lmr; func_239061_d_
 dud$1 net/minecraft/client/gui/screen/WorldOptionsScreen$1
 	a field_239062_a_
-	c ()Lmx; func_230442_c_
-	i ()Lmr; func_230458_i_
+	c ()Lmx; func_230442_c_ getNarrationMessage
+	i ()Lmr; func_230458_i_ getMessage
 dud$2 net/minecraft/client/gui/screen/WorldOptionsScreen$2
 	a field_239063_a_
-	c ()Lmx; func_230442_c_
-	i ()Lmr; func_230458_i_
+	c ()Lmx; func_230442_c_ getNarrationMessage
+	i ()Lmr; func_230458_i_ getMessage
 dud$3 net/minecraft/client/gui/screen/WorldOptionsScreen$3
 	a field_239064_a_
 	b field_239065_b_
-	i ()Lmr; func_230458_i_
+	i ()Lmr; func_230458_i_ getMessage
 due net/minecraft/client/gui/screen/BiomeGeneratorTypeScreens
 	a field_239066_a_
 	b field_239067_b_
@@ -56142,15 +56142,15 @@ duf net/minecraft/client/gui/screen/WorldSelectionList
 	q field_214379_d
 	r field_186798_v
 	s field_212331_y
-	a (Ldne$a;)V func_241215_a_
-	a (Ldne$b;)V func_241219_a_
-	a (Lduf$a;)V func_241215_a_
+	a (Ldne$a;)V func_241215_a_ setSelected
+	a (Ldne$b;)V func_241219_a_ moveSelection
+	a (Lduf$a;)V func_241215_a_ setSelected
 	a (Lduf;)I func_214375_a
 	a (Ljava/util/function/Supplier;Z)V func_212330_a
-	b ()Z func_230971_aw__
+	b ()Z func_230971_aw__ isFocused
 	b (Lduf$a;)Z func_241652_b_
-	d ()I func_230949_c_
-	e ()I func_230952_d_
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
 	f ()Ljava/util/Optional; func_214376_a
 	g ()Lduc; func_186796_g
 	s ()Ljava/text/DateFormat; func_214371_c
@@ -56167,10 +56167,10 @@ duf$a net/minecraft/client/gui/screen/WorldSelectionList$Entry
 	g field_214454_g
 	h field_214455_h
 	a ()V func_214438_a
-	a (DDI)Z func_231044_a_
+	a (DDI)Z func_231044_a_ mouseClicked
 	a (Lbqe;Lcix;Ljava/nio/file/Path;Lgm$a;Z)V func_239095_a_
 	a (Ldae$a;Ljava/lang/String;Z)V func_239096_a_
-	a (Ldhl;IIIIIIIZF)V func_230432_a_
+	a (Ldhl;IIIIIIIZF)V func_230432_a_ render
 	a (Lduf$a;)Ldaf; func_214437_a
 	a (Z)V func_214440_b
 	a (ZZ)V func_214436_a
@@ -63391,10 +63391,10 @@ eqb net/minecraft/realms/DisconnectedRealmsScreen
 	c field_230715_c_
 	p field_230716_p_
 	q field_230717_q_
-	a (III)Z func_231046_a_
-	a (Ldhl;IIF)V func_230430_a_
+	a (III)Z func_231046_a_ keyPressed
+	a (Ldhl;IIF)V func_230430_a_ render
 	a (Ldlx;Ldni;)V func_239547_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 eqc net/minecraft/realms/RealmsNarratorHelper
 	a field_239548_a_
 	a (Ljava/lang/Iterable;)V func_239549_a_
@@ -63406,7 +63406,7 @@ eqc net/minecraft/realms/RealmsNarratorHelper
 eqd net/minecraft/realms/RealmsBridgeScreen
 	a field_230718_a_
 	a (Ldqs;)V func_231394_a_
-	b ()V func_231160_c_
+	b ()V func_231160_c_ init
 	b (Ldqs;)Leqh; func_239555_b_
 eqe net/minecraft/realms/RealmsConnect
 	a field_230719_a_
@@ -63441,18 +63441,18 @@ eqg net/minecraft/realms/RealmsObjectSelectionList
 	a ()V func_231409_q_
 	a (I)V func_231400_a_
 	a (IIDDI)V func_231401_a_
-	a (Ldnt$a;)I func_230513_b_
-	a (Ljava/util/Collection;)V func_230942_a_
-	b (Ldne$a;)I func_230513_b_
-	c ()I func_230945_b_
-	d ()I func_230949_c_
-	e ()I func_230952_d_
-	h (I)I func_230962_i_
+	a (Ldnt$a;)I func_230513_b_ addEntry
+	a (Ljava/util/Collection;)V func_230942_a_ replaceEntries
+	b (Ldne$a;)I func_230513_b_ addEntry
+	c ()I func_230945_b_ getMaxPosition
+	d ()I func_230949_c_ getRowWidth
+	e ()I func_230952_d_ getScrollbarPosition
+	h (I)I func_230962_i_ getRowTop
 	j (I)V func_239561_k_
-	l ()I func_230965_k_
-	q ()I func_230968_n_
+	l ()I func_230965_k_ getItemCount
+	q ()I func_230968_n_ getRowLeft
 eqh net/minecraft/realms/RealmsScreen
-	d ()V func_231023_e_
+	d ()V func_231023_e_ tick
 	k (I)I func_239562_k_
 	u ()V func_231411_u_
 eqi net/minecraft/realms/RealmsServerAddress


### PR DESCRIPTION
Based on Covers' mapping list, applied by a script:
https://gist.github.com/covers1624/75534a5ba9193644800dbcd172effd9e

