### PR TITLE
Fixed error preventing 1.12.2-1.13.2 from building

### DIFF
--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateAccessFixes.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateAccessFixes.groovy
@@ -13,7 +13,7 @@ public class CreateAccessFixes extends SingleFileOutput {
     
     @TaskAction
     protected void exec() {
-        def dziwne = IMappingFile.load(srg)
+        def srg0 = IMappingFile.load(srg)
         def json = new JsonSlurper().parseText(meta.text)
         dest.withWriter('UTF-8') { writer ->
             json.each{ k,v ->
@@ -28,11 +28,11 @@ public class CreateAccessFixes extends SingleFileOutput {
                                 if (old < top) {
                                     def name = sig.split(' ')[0]
                                     def desc = sig.split(' ')[1]
-                                    def mapped = dziwne.getClass(k)?.remapMethod(name, desc)
+                                    def mapped = srg0.getClass(k)?.remapMethod(name, desc)
                                     if (mapped == null) {
                                         print('Missing srg mapping for access: ' + k + '/' + sig + '\n')
                                     } else {
-                                        writer.write(names[top] + ' ' + dziwne.remapClass(k) + ' ' + mapped + ' ' + dziwne.remapDescriptor(desc) + '\n')
+                                        writer.write(names[top] + ' ' + srg0.remapClass(k) + ' ' + mapped + ' ' + srg0.remapDescriptor(desc) + '\n')
                                     }
                                 }
                             }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateAccessFixes.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateAccessFixes.groovy
@@ -13,7 +13,7 @@ public class CreateAccessFixes extends SingleFileOutput {
     
     @TaskAction
     protected void exec() {
-        def srgO = IMappingFile.load(srg)
+        def dziwne = IMappingFile.load(srg)
         def json = new JsonSlurper().parseText(meta.text)
         dest.withWriter('UTF-8') { writer ->
             json.each{ k,v ->
@@ -28,11 +28,11 @@ public class CreateAccessFixes extends SingleFileOutput {
                                 if (old < top) {
                                     def name = sig.split(' ')[0]
                                     def desc = sig.split(' ')[1]
-                                    def mapped = srgO.class(k)?.remapMethod(name, desc)
+                                    def mapped = dziwne.getClass(k)?.remapMethod(name, desc)
                                     if (mapped == null) {
                                         print('Missing srg mapping for access: ' + k + '/' + sig + '\n')
                                     } else {
-                                        writer.write(names[top] + ' ' + srgO.remapClass(k) + ' ' + mapped + ' ' + srgO.remapDescriptor(desc) + '\n')
+                                        writer.write(names[top] + ' ' + dziwne.remapClass(k) + ' ' + mapped + ' ' + dziwne.remapDescriptor(desc) + '\n')
                                     }
                                 }
                             }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateAccessFixes.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateAccessFixes.groovy
@@ -13,7 +13,7 @@ public class CreateAccessFixes extends SingleFileOutput {
     
     @TaskAction
     protected void exec() {
-        def srg0 = IMappingFile.load(srg)
+        def srgO = IMappingFile.load(srg)
         def json = new JsonSlurper().parseText(meta.text)
         dest.withWriter('UTF-8') { writer ->
             json.each{ k,v ->
@@ -28,11 +28,11 @@ public class CreateAccessFixes extends SingleFileOutput {
                                 if (old < top) {
                                     def name = sig.split(' ')[0]
                                     def desc = sig.split(' ')[1]
-                                    def mapped = srg0.getClass(k)?.remapMethod(name, desc)
+                                    def mapped = srgO.getClass(k)?.remapMethod(name, desc)
                                     if (mapped == null) {
                                         print('Missing srg mapping for access: ' + k + '/' + sig + '\n')
                                     } else {
-                                        writer.write(names[top] + ' ' + srg0.remapClass(k) + ' ' + mapped + ' ' + srg0.remapDescriptor(desc) + '\n')
+                                        writer.write(names[top] + ' ' + srgO.remapClass(k) + ' ' + mapped + ' ' + srgO.remapDescriptor(desc) + '\n')
                                     }
                                 }
                             }


### PR DESCRIPTION
I have no idea if this repo is still alive (if not, is there any replacement?)
./gradlew 1.12.2:build was failing for me:

```
2020-07-21T03:23:14.335+0200 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] FAILURE: Build failed with an exception.
2020-07-21T03:23:14.335+0200 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] 
2020-07-21T03:23:14.335+0200 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] * What went wrong:
2020-07-21T03:23:14.335+0200 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] Execution failed for task ':1.12.2:fixAccessLevels'.
2020-07-21T03:23:14.335+0200 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] > No signature of method: net.minecraftforge.srgutils.MappingFile.class() is applicable for argument types: (String) values: [chd]
2020-07-21T03:23:14.335+0200 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   Possible solutions: getClass(java.lang.String), getClass(), chain(net.minecraftforge.srgutils.IMappingFile), wait(), any(), equals(java.lang.Object)
```

This PR fixes it. This bug (calling .class instead of .getClass) wasn't triggered in newer versions - this part of code (entering `if (old < top)`) was never executed in those versions.