### PR TITLE
Fix reference of <cinit> to <clinit>

### DIFF
--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ExtractAPI.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ExtractAPI.groovy
@@ -16,7 +16,7 @@ public class ExtractAPI extends SingleFileOutput {
     @TaskAction
     protected void exec() {
         def BAD_ACCESS = Opcodes.ACC_PRIVATE //Filter synthetic?
-        def BLACKLIST = ['<cinit>()V']
+        def BLACKLIST = ['<clinit>()V']
         
         def api = [] as TreeMap
         

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ExtractInheritance.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ExtractInheritance.groovy
@@ -73,7 +73,7 @@ public class ExtractInheritance extends SingleFileOutput {
         cls.interfaces.each{ resolveClass(getClassInfo, getClassInfo.apply(it)) }
         
         cls.methods.values().each{ mtd ->
-            if ('<init>'.equals(mtd.name) || '<cinit>'.equals(mtd.name) || ((mtd.access ?: 0) & (ACC_PRIVATE | ACC_STATIC)) != 0)
+            if ('<init>'.equals(mtd.name) || '<clinit>'.equals(mtd.name) || ((mtd.access ?: 0) & (ACC_PRIVATE | ACC_STATIC)) != 0)
                 return
             
             def override

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/MigrateMappings.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/MigrateMappings.groovy
@@ -351,7 +351,7 @@ public class MigrateMappings extends DefaultTask {
         def name = data.force ?: forced.get(id)
         if (debug) logger.lifecycle('A: ' + name)
         
-        if (mname.charAt(0) == '<') //  <init> and <cinit> are special and must be named this
+        if (mname.charAt(0) == '<') //  <init> and <clinit> are special and must be named this
             name = mname
         if (debug) logger.lifecycle('B: ' + name)
             


### PR DESCRIPTION
According to the Java:tm: Virtual Machine Specification, Java SE 8 Edition, Ch. 2 "The Structure of the Java Virtual Machine", [§ 2.9 "Special Methods"][jvms-8-2.9]:
> A class or interface has at most one _class or interface initialization method_ and is initialized ([§5.5][jvms-8-5.5]) by invoking that method. The initialization method of a class or interface has the special name `<clinit>`, takes no arguments, and is void ([§4.3.3][jvms-8-4.3.3]). 

MCPConfig references `<cinit>` instead of `<clinit>` in three places _(one of which is a comment)_, which may cause issues relating to the class/interface initialization method. This PR fixes those references.

[jvms-8-5.5]: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.5
[jvms-8-4.3.3]: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.3
[jvms-8-2.9]: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.9