### PR TITLE
match param ids instead of generating a new id for each

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url = 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'net.minecraftforge:srgutils:0.4.1'
+        classpath 'net.minecraftforge:srgutils:0.4.3'
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'com.google.guava:guava:25.1-jre'
     implementation 'org.ow2.asm:asm:8.0.1'
     implementation 'org.ow2.asm:asm-tree:8.0.1'
-    implementation 'net.minecraftforge:srgutils:0.4.1'
+    implementation 'net.minecraftforge:srgutils:0.4.3'
     implementation 'org.tukaani:xz:1.8' // Extract API, to extract the runtime jars, as Mojang uses lzma
     implementation 'de.undercouch:gradle-download-task:4.1.1' // Bulk DownloadLibraries task
     implementation 'net.minecraftforge:mapping-verifier:2.0.2'

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/MigrateMappings.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/MigrateMappings.groovy
@@ -49,7 +49,7 @@ public class MigrateMappings extends DefaultTask {
         Utils.init()
     
         def official = loadMappings(current.official).getMap('left', 'right')
-        def matches = loadMappings(current.map).getMap('left', 'right').reverse()
+        def matches = loadMappings(current.map).getMap('right', 'left')
         def meta = new JsonSlurper().parse(current.meta)
         meta.removeAll{ it.key.contains('minecraftforge') }
         


### PR DESCRIPTION
The `genParamId` is straightforward, just find the old method if it exists and extract the parameter at the proper index.
Thing is, the `oldtonew.tsrg` which is loaded in `matches` does not have the `<init>` functions, so for that I remap the descriptor manually, knowing that if the descriptor changed `getMethod()` will return null, so it will still find the proper method if it exists.

However, then I realized that the desc for some functions were incorrect, and they had `DataResult` mapped to `DataResult$PartialResult`. I fixed this by loading the `oldtonew.tsrg` in the "correct" order, left -> right, then reversing, instead of doing right -> left. But, I still have no idea what the cause is... probably would need to debug SrgUtils for that