### PR TITLE
Fix missing space causing patch apply to fail

### DIFF
--- a/versions/pre/1.17/1.17-rc2/patches/shared/net/minecraft/advancements/critereon/EntityTypePredicate.java.patch
+++ b/versions/pre/1.17/1.17-rc2/patches/shared/net/minecraft/advancements/critereon/EntityTypePredicate.java.patch
@@ -2,7 +2,7 @@
 +++ b/net/minecraft/advancements/critereon/EntityTypePredicate.java
 @@ -69,7 +69,7 @@
        }
-
+ 
        public JsonElement m_5908_() {
 -         return new JsonPrimitive("#" + SerializationTags.m_13199_().m_144454_(Registry.f_122903_, this.f_37653_, () -> {
 +         return new JsonPrimitive("#" + SerializationTags.m_13199_().<EntityType, IllegalStateException>m_144454_(Registry.f_122903_, this.f_37653_, () -> {

--- a/versions/release/1.17/patches/shared/net/minecraft/advancements/critereon/EntityTypePredicate.java.patch
+++ b/versions/release/1.17/patches/shared/net/minecraft/advancements/critereon/EntityTypePredicate.java.patch
@@ -2,7 +2,7 @@
 +++ b/net/minecraft/advancements/critereon/EntityTypePredicate.java
 @@ -69,7 +69,7 @@
        }
-
+ 
        public JsonElement m_5908_() {
 -         return new JsonPrimitive("#" + SerializationTags.m_13199_().m_144454_(Registry.f_122903_, this.f_37653_, () -> {
 +         return new JsonPrimitive("#" + SerializationTags.m_13199_().<EntityType, IllegalStateException>m_144454_(Registry.f_122903_, this.f_37653_, () -> {


### PR DESCRIPTION
Seems like Cyborgmas somehow deleted a space in this patch file, causing DiffPatch to filter it out and fail when setting up MCP and applying patches. Fixed for both 1.17 and 1.17-rc2.