### PR TITLE
Update Vignette to 0.2.0.10

### DIFF
--- a/versions/release/1.17/config.json
+++ b/versions/release/1.17/config.json
@@ -15,7 +15,7 @@
     },
     "rename": {
         "version": "net.minecraftforge.lex:vignette:0.2.0.10",
-        "args": ["--jar-in", "{input}", "--jar-out", "{output}", "--mapping-format", "tsrg2", "--mappings", "{mappings}", "--fernflower-meta", "--cfg", "{libraries}", "--create-inits", "--fix-param-annotations"]
+        "args": ["--jar-in", "{input}", "--jar-out", "{output}", "--mapping-format", "tsrg2", "--mappings", "{mappings}", "--fernflower-meta", "--cfg", "{libraries}", "--create-inits", "--fix-param-annotations", "--threads", "1"]
     },
     "libraries": {
         "client": ["com.google.code.findbugs:jsr305:3.0.1"],

--- a/versions/release/1.17/config.json
+++ b/versions/release/1.17/config.json
@@ -14,7 +14,7 @@
         "jvmargs": []
     },
     "rename": {
-        "version": "net.minecraftforge.lex:vignette:0.2.0.9",
+        "version": "net.minecraftforge.lex:vignette:0.2.0.10",
         "args": ["--jar-in", "{input}", "--jar-out", "{output}", "--mapping-format", "tsrg2", "--mappings", "{mappings}", "--fernflower-meta", "--cfg", "{libraries}", "--create-inits", "--fix-param-annotations"]
     },
     "libraries": {

--- a/versions/release/1.17/config.json
+++ b/versions/release/1.17/config.json
@@ -14,8 +14,8 @@
         "jvmargs": []
     },
     "rename": {
-        "version": "net.minecraftforge.lex:vignette:0.2.0.10",
-        "args": ["--jar-in", "{input}", "--jar-out", "{output}", "--mapping-format", "tsrg2", "--mappings", "{mappings}", "--fernflower-meta", "--cfg", "{libraries}", "--create-inits", "--fix-param-annotations", "--threads", "1"]
+        "version": "net.minecraftforge.lex:vignette:0.2.0.11",
+        "args": ["--jar-in", "{input}", "--jar-out", "{output}", "--mapping-format", "tsrg2", "--mappings", "{mappings}", "--fernflower-meta", "--cfg", "{libraries}", "--create-inits", "--fix-param-annotations", "--stable"]
     },
     "libraries": {
         "client": ["com.google.code.findbugs:jsr305:3.0.1"],


### PR DESCRIPTION
Updates vignette including the lambda remapping fix.