### PR TITLE
Update mergetool for 22w13oneBlockAtATime

### DIFF
--- a/versions/snapshot/april/22w13oneblockatatime/config.json
+++ b/versions/snapshot/april/22w13oneblockatatime/config.json
@@ -9,7 +9,7 @@
         "jvmargs": ["-Xmx4G"]
     },
     "merge": {
-        "version": "net.minecraftforge:mergetool:1.1.4:fatjar",
+        "version": "net.minecraftforge:mergetool:1.1.5:fatjar",
         "args": ["--client", "{client}", "--server", "{server}", "--ann", "{version}", "--output", "{output}", "--inject", "false"],
         "jvmargs": []
     },
@@ -28,6 +28,6 @@
     "libraries": {
         "client": ["com.google.code.findbugs:jsr305:3.0.1", "ca.weblite:java-objc-bridge:1.0.0", "org.jetbrains:annotations:23.0.0"],
         "server": ["com.google.code.findbugs:jsr305:3.0.1", "org.jetbrains:annotations:23.0.0"],
-        "joined": ["com.google.code.findbugs:jsr305:3.0.1", "ca.weblite:java-objc-bridge:1.0.0", "net.minecraftforge:mergetool:1.1.4:api", "org.jetbrains:annotations:23.0.0"]
+        "joined": ["com.google.code.findbugs:jsr305:3.0.1", "ca.weblite:java-objc-bridge:1.0.0", "net.minecraftforge:mergetool:1.1.5:api", "org.jetbrains:annotations:23.0.0"]
     }
 }


### PR DESCRIPTION
Update mergetool so that it includes the SrgUtils version with support for 22w13oneBlockAtATime.