### PR TITLE
[1.19] Update java-objc-bridge to 1.1 to support M1 macs

### DIFF
--- a/versions/release/1.19/config.json
+++ b/versions/release/1.19/config.json
@@ -26,8 +26,8 @@
         "args": ["--task", "bundler_extract", "--input", "{input}", "--output", "{output}", "--libraries"]
     },
     "libraries": {
-        "client": ["com.google.code.findbugs:jsr305:3.0.1", "ca.weblite:java-objc-bridge:1.0.0", "org.jetbrains:annotations:23.0.0"],
+        "client": ["com.google.code.findbugs:jsr305:3.0.1", "ca.weblite:java-objc-bridge:1.1", "org.jetbrains:annotations:23.0.0"],
         "server": ["com.google.code.findbugs:jsr305:3.0.1", "org.jetbrains:annotations:23.0.0"],
-        "joined": ["com.google.code.findbugs:jsr305:3.0.1", "ca.weblite:java-objc-bridge:1.0.0", "net.minecraftforge:mergetool:1.1.5:api", "org.jetbrains:annotations:23.0.0"]
+        "joined": ["com.google.code.findbugs:jsr305:3.0.1", "ca.weblite:java-objc-bridge:1.1", "net.minecraftforge:mergetool:1.1.5:api", "org.jetbrains:annotations:23.0.0"]
     }
 }


### PR DESCRIPTION
Fixes issues with M1 macs not being able to run in userdev/forgedev. This is due to an outdated java-objc-bridge version. Mojang is using 1.1 while MCPConfig is using 1.0.0. Version 1.1 adds support for M1 macs. Simple fix, validated by @mezz.