### PR TITLE
Optimise and cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'uk.jamierocks.propatcher' version '2.0.1' apply false
 }
 
+import de.undercouch.gradle.tasks.download.Download
 import net.minecraftforge.mcpconfig.tasks.*
 import net.minecraftforge.srgutils.MinecraftVersion
 import uk.jamierocks.propatcher.task.*
@@ -11,22 +12,21 @@ group = 'de.oceanlabs.mcp'
 
 net.minecraftforge.mcpconfig.tasks.Utils.init()
 
+final String PATH_BUILD = file('build').absolutePath
+final MinecraftVersion MC_1_16_5 = MinecraftVersion.from('1.16.5')
+final List<String> VERSIONS = subprojects.collect{it.name}.sort{ a,b -> MinecraftVersion.from(a) <=> MinecraftVersion.from(b) }
+final String TIMESTAMP = (new Date()).format('yyyyMMdd.HHmmss')
 ext {
-    MC_1_16_5 = MinecraftVersion.from('1.16.5')
-    VERSIONS = subprojects.collect{it.name}.sort{ a,b -> MinecraftVersion.from(a).compareTo(MinecraftVersion.from(b)) } as List
-    NULL_OUTPUT = new OutputStream() { public void write(int b){} }
-    TIMESTAMP = (new Date()).format('yyyyMMdd.HHmmss')
-    PATH_BUILD = file('build').absolutePath
-
     ASM_VERSION = '9.2'
     SRGUTILS_VERSION = '0.5.3'
 }
 
 logger.lifecycle('Timestamp: ' + TIMESTAMP)
 
-task downloadVersionManifest(type: Download) {
+final File downloadVersionManifestDest = file('build/versions/version_manifest.json')
+tasks.register('downloadVersionManifest', Download) {
     src 'https://launchermeta.mojang.com/mc/game/version_manifest_v2.json'
-    dest file('build/versions/version_manifest.json')
+    dest downloadVersionManifestDest
     useETag 'all'
     onlyIfModified true
     quiet true
@@ -74,18 +74,15 @@ subprojects {
     group = rootProject.group
     version = name
 
+    final MinecraftVersion MC_VERSION = MinecraftVersion.from(project.name)
+    final String PATH_CACHED_LIBRARIES = PATH_BUILD + '/libraries/'
+    final String PATH_CACHED_VERSION = PATH_BUILD + '/versions/' + project.version + '/'
+    final String PATH_CACHED_VERSION_DATA = PATH_CACHED_VERSION + 'data/'
+    final File PATH_INJECT = file('inject')
+    final File PATH_INJECT_TEMPLATE = new File(PATH_INJECT, 'package-info-template.java')
+    final File PATH_NATIVES = file('projects/natives')
     ext {
-        MC_VERSION = MinecraftVersion.from(project.name)
-        PATH_CACHED_LIBRARIES = PATH_BUILD + '/libraries/'
-        PATH_CACHED_VERSION = PATH_BUILD + '/versions/' + project.version + '/'
-        PATH_CACHED_VERSION_DATA = PATH_CACHED_VERSION + 'data/'
-        
-        PATH_INJECT = file('inject')
-        PATH_INJECT_TEMPLATE = new File(PATH_INJECT, 'package-info-template.java')
-        PATH_NATIVES = file('projects/natives')
-
         CONFIG = file('config.json').json
-        MERGE_PATCHES = !rootProject.hasProperty('updating') && CONFIG.get('merge_patches', false)
         JAVA_TARGET = CONFIG.get('java_target', 8)
         ENCODING = CONFIG.get('encoding', 'UTF-8')
         FERNFLOWER = Utils.readConfig(CONFIG, 'fernflower', [:])        
@@ -111,6 +108,7 @@ subprojects {
         if (CONFIG.containsKey('bundler_extract_libs'))
             BUNDLE_EXTRACT_LIBS = Utils.readConfig(CONFIG, 'bundler_extract_libs', [:])
     }
+    final boolean MERGE_PATCHES = !rootProject.hasProperty('updating') && CONFIG.get('merge_patches', false)
 
     java.toolchain.languageVersion = JavaLanguageVersion.of(JAVA_TARGET)
 
@@ -129,91 +127,137 @@ subprojects {
         srgutilsJar "net.minecraftforge:srgutils:${SRGUTILS_VERSION}"
     }
 
-    task downloadJson(type: Download, dependsOn: rootProject.downloadVersionManifest) {
-        inputs.file rootProject.downloadVersionManifest.dest
-        src { downloadVersionManifest.dest.json.versions.find{ it.id == project.name }.url }
-        dest file(PATH_CACHED_VERSION + 'version.json')
+    final File downloadJsonDest = file(PATH_CACHED_VERSION + 'version.json')
+    tasks.register('downloadJson', Download) {
+        dependsOn ':downloadVersionManifest'
+        inputs.file downloadVersionManifestDest
+        src { downloadVersionManifestDest.json.versions.find { it.id == project.name }.url }
+        dest downloadJsonDest
         useETag 'all'
         onlyIfModified true
         quiet true
     }
-    ['client', 'server', 'client_mappings', 'server_mappings'].each { id ->
-        def name = 'download' + id.replace('_m', 'M').capitalize()
-        task "${name}"(type: Download, dependsOn: downloadJson) {
-            inputs.file downloadJson.dest
-            src { downloadJson.dest.json.downloads.get(id).url }
-            dest file(PATH_CACHED_VERSION + id + (id.contains('_') ? '.txt' : '.jar'))
-            useETag 'all'
-            onlyIfModified true
-            quiet true
-        }
+
+    final File downloadClientDest = file(PATH_CACHED_VERSION + 'client.jar')
+    tasks.register('downloadClient', Download) {
+        dependsOn 'downloadJson'
+        inputs.file downloadJsonDest
+        src { downloadJsonDest.json.downloads.get('client').url }
+        dest downloadClientDest
+        useETag 'all'
+        onlyIfModified true
+        quiet true
     }
-    
-    task downloadLibraries(type: DownloadLibraries, dependsOn: downloadJson) {
-        json = downloadJson.dest
+
+    final File downloadServerDest = file(PATH_CACHED_VERSION + 'server.jar')
+    tasks.register('downloadServer', Download) {
+        dependsOn 'downloadJson'
+        inputs.file downloadJsonDest
+        src { downloadJsonDest.json.downloads.get('server').url }
+        dest downloadServerDest
+        useETag 'all'
+        onlyIfModified true
+        quiet true
+    }
+
+    final File downloadClientMappingsDest = file(PATH_CACHED_VERSION + 'client_mappings.txt')
+    tasks.register('downloadClientMappings', Download) {
+        dependsOn 'downloadJson'
+        inputs.file downloadJsonDest
+        src { downloadJsonDest.json.downloads.get('client_mappings').url }
+        dest downloadClientMappingsDest
+        useETag 'all'
+        onlyIfModified true
+        quiet true
+    }
+
+    final File downloadServerMappingsDest = file(PATH_CACHED_VERSION + 'server_mappings.txt')
+    tasks.register('downloadServerMappings', Download) {
+        dependsOn 'downloadJson'
+        inputs.file downloadJsonDest
+        src { downloadJsonDest.json.downloads.get('server_mappings').url }
+        dest downloadServerMappingsDest
+        useETag 'all'
+        onlyIfModified true
+        quiet true
+    }
+
+    tasks.register('downloadLibraries', DownloadLibraries) {
+        dependsOn 'downloadJson', 'downloadBundleExtractorLibs', 'downloadBundleExtractorJar', 'downloadRenameTool', 'downloadFernflower', 'downloadMergeTool'
+        json = downloadJsonDest
         config = CONFIG
         dest = file(PATH_CACHED_LIBRARIES)
     }
-    task downloadFernflower(type: DownloadTool) {
+
+    tasks.register('downloadFernflower', DownloadTool) {
         config FERNFLOWER, PATH_CACHED_LIBRARIES
     }
-    task downloadMergeTool(type: DownloadTool) {
+    tasks.register('downloadMergeTool', DownloadTool) {
         config MERGETOOL, PATH_CACHED_LIBRARIES
     }
-    task downloadRenameTool(type: DownloadTool) {
+    tasks.register('downloadRenameTool', DownloadTool) {
         config RENAMETOOL, PATH_CACHED_LIBRARIES
     }
-    task downloadAssets(type: DownloadAssets, dependsOn: downloadJson) {
-        json = downloadJson.dest
-        dest = file(PATH_BUILD + '/assets/')
+
+    final File downloadAssetsDest = file(PATH_BUILD + '/assets/')
+    tasks.register('downloadAssets', DownloadAssets) {
+        dependsOn 'downloadJson'
+        json = downloadJsonDest
+        dest = downloadAssetsDest
     }
+
+    final File makeEmptyFileDest = file(PATH_BUILD + '/empty.txt')
     if (MCINJECTOR != null) {
-        task downloadMCInjector(type: DownloadTool) {
+        tasks.register('downloadMCInjector', DownloadTool) {
             config MCINJECTOR, PATH_CACHED_LIBRARIES
         }
-        task makeEmptyFile(type: SingleFileOutput) {
-            dest file(PATH_BUILD + '/empty.txt')
+        tasks.register('makeEmptyFile', SingleFileOutput) {
+            dest makeEmptyFileDest
             doLast {
                 dest.text = ''
             }
         }
     }
-    
+
+    final File extractServerDest = file(PATH_CACHED_VERSION + 'server.extracted.jar')
+    final File extractServerLibrariesDest = file(PATH_CACHED_VERSION + 'server_libraries')
     if (BUNDLE_EXTRACT_JAR != null) {
-        task downloadBundleExtractorJar(type: DownloadTool) {
+        tasks.register('downloadBundleExtractorJar', DownloadTool) {
             config BUNDLE_EXTRACT_JAR, PATH_CACHED_LIBRARIES
         }
-        task downloadBundleExtractorLibs(type: DownloadTool) {
+        tasks.register('downloadBundleExtractorLibs', DownloadTool) {
             config BUNDLE_EXTRACT_LIBS, PATH_CACHED_LIBRARIES
         }
-        task extractServer(type: ExtractBundleJar, dependsOn: [downloadBundleExtractorJar, downloadBundleExtractorLibs, downloadServer]) {
-            config BUNDLE_EXTRACT_JAR, downloadBundleExtractorJar
-            input = downloadServer.dest
-            dest = file(PATH_CACHED_VERSION + 'server.extracted.jar')
+        tasks.register('extractServer', ExtractBundleJar) {
+            dependsOn 'downloadBundleExtractorJar', 'downloadBundleExtractorLibs', 'downloadServer'
+            config BUNDLE_EXTRACT_JAR, tasks.downloadBundleExtractorJar
+            input = downloadServerDest
+            dest = extractServerDest
         }
-        task extractServerLibraries(type: ExtractBundleLibs, dependsOn: [downloadBundleExtractorJar, downloadBundleExtractorLibs, downloadServer]) {
-            config BUNDLE_EXTRACT_LIBS, downloadBundleExtractorLibs
-            input = downloadServer.dest
-            dest = file(PATH_CACHED_VERSION + 'server_libraries')
+        tasks.register('extractServerLibraries', ExtractBundleLibs) {
+            dependsOn 'downloadBundleExtractorJar', 'downloadBundleExtractorLibs', 'downloadServer'
+            config BUNDLE_EXTRACT_LIBS, tasks.downloadBundleExtractorLibs
+            input = downloadServerDest
+            dest = extractServerLibrariesDest
         }
     }
     
-    task filterClient(type: SplitJar, dependsOn: [downloadClient]) {
+    task filterClient(type: SplitJar, dependsOn: 'downloadClient') {
         mappings = file('joined.tsrg')
-        source = downloadClient.dest
+        source = downloadClientDest
         slim = file(PATH_CACHED_VERSION + 'client.slim.jar')
         extra = file(PATH_CACHED_VERSION + 'client.extra.jar')
     }
     
-    task filterServer(type: SplitJar, dependsOn: BUNDLE_EXTRACT_JAR == null ? [downloadServer] : [extractServer]) {
+    task filterServer(type: SplitJar, dependsOn: BUNDLE_EXTRACT_JAR == null ? ['downloadServer'] : ['extractServer']) {
         mappings = file('joined.tsrg')
-        source = BUNDLE_EXTRACT_JAR == null ? downloadServer.dest : extractServer.dest
+        source = BUNDLE_EXTRACT_JAR == null ? downloadServerDest : extractServerDest
         slim = file(PATH_CACHED_VERSION + 'server.slim.jar')
         extra = file(PATH_CACHED_VERSION + 'server.extra.jar')
     }
 
-    task mergeJars(type: MergeJar, dependsOn: [downloadMergeTool, filterClient, filterServer]) {
-        config MERGETOOL, downloadMergeTool
+    task mergeJars(type: MergeJar, dependsOn: ['downloadMergeTool', filterClient, filterServer]) {
+        config MERGETOOL, tasks.downloadMergeTool
         classpath = configurations.srgutilsJar
         classpath.from project.files(downloadMergeTool)
         mainClass = 'net.minecraftforge.mergetool.ConsoleMerger'
@@ -222,23 +266,25 @@ subprojects {
         version project.version
         dest file(PATH_CACHED_VERSION + 'joined.jar')
     }
-    
-    task makeObfToIntermediate(type: RenameMappings, dependsOn: [downloadClientMappings]) {
+
+    final File makeObfToIntermediateDest = file(PATH_CACHED_VERSION + 'obf_to_intermediate.tsrg')
+    tasks.register('makeObfToIntermediate', RenameMappings) {
+        dependsOn 'downloadClientMappings'
         intermediate = file('joined.tsrg')
         if (CONFIG.official)
-            official = downloadClientMappings.dest
-        dest = file(PATH_CACHED_VERSION + 'obf_to_intermediate.tsrg')
+            official = downloadClientMappingsDest
+        dest = makeObfToIntermediateDest
     }
 
     def sides = [
-        client: [Name: 'Client', jsonlibs: true,  extra: 'Client', assets: true,  slim: filterClient, extra: filterClient, bundle: null],
-        server: [Name: 'Server', jsonlibs: false, extra: 'Server', assets: false, slim: filterServer, extra: filterServer, bundle: downloadServer],
-        joined: [Name: 'Joined', jsonlibs: true,  extra: 'Client', assets: true,  slim: mergeJars,    extra: filterClient, bundle: null]
+        client: [Name: 'Client', jsonlibs: true,  assets: true,  slim: filterClient, extra: filterClient, bundle: null],
+        server: [Name: 'Server', jsonlibs: false, assets: false, slim: filterServer, extra: filterServer, bundle: downloadServer],
+        joined: [Name: 'Joined', jsonlibs: true,  assets: true,  slim: mergeJars,    extra: filterClient, bundle: null]
     ]
     
-    sides.each{ s, child ->
-        child.libraries = task "fernflowerLibraries${child.Name}"(type: CreateFernflowerLibraries, dependsOn: [downloadLibraries, downloadJson, child.slim] + (BUNDLE_EXTRACT_LIBS == null ? [] : [extractServerLibraries])) {
-            meta = downloadJson.dest
+    sides.each { String s, def child ->
+        child.libraries = task "fernflowerLibraries${child.Name}"(type: CreateFernflowerLibraries, dependsOn: ['downloadLibraries', 'downloadJson', child.slim] + (BUNDLE_EXTRACT_LIBS == null ? [] : ['extractServerLibraries'])) {
+            meta = downloadJsonDest
             config = CONFIG
             side = s
             root = PATH_CACHED_LIBRARIES
@@ -246,93 +292,105 @@ subprojects {
                 if ('server'.equals(s)) {
                     extras += [filterServer.extra]
                     if (BUNDLE_EXTRACT_LIBS != null)
-                        extractServerLibraries.dest.eachFileRecurse(groovy.io.FileType.FILES) { file -> extras += [file] }
+                        extractServerLibrariesDest.eachFileRecurse(groovy.io.FileType.FILES) { file -> extras += [file] }
                 }
             }
             dest file(PATH_CACHED_VERSION + s + '.fernflower.libs.txt')
         }
         
-        child.rename = task "rename${child.Name}"(type: RemapJar, dependsOn: [downloadRenameTool, child.slim, makeObfToIntermediate, child.libraries]) {
+        child.rename = task "rename${child.Name}"(type: RemapJar, dependsOn: ['downloadRenameTool', child.slim, 'makeObfToIntermediate', child.libraries]) {
             config RENAMETOOL, downloadRenameTool
             input = 'joined'.equals(s) ? child.slim.dest : child.slim.slim
-            mappings = makeObfToIntermediate.dest
+            mappings = makeObfToIntermediateDest
             libraries = child.libraries.dest
             dest = file(PATH_CACHED_VERSION + s + '.mapped.jar')
             log = file(PATH_CACHED_VERSION + s + '.mapped.log')
         }
         
         if (MCINJECTOR != null) {
-            child.mcinject = task "mcinject${child.Name}"(type: MCInjectTask, dependsOn: [downloadMCInjector, child.rename, makeEmptyFile/*, makeExceptions, fixAccessLevels*/]) {
+            final OutputStream NULL_OUTPUT = new OutputStream() { void write(int b) {} }
+            child.mcinject = task "mcinject${child.Name}"(type: MCInjectTask, dependsOn: ['downloadMCInjector', child.rename, 'makeEmptyFile'/*, makeExceptions, fixAccessLevels*/]) {
                 config MCINJECTOR, downloadMCInjector
-                access makeEmptyFile.dest //fixAccessLevels.dest
+                access makeEmptyFileDest //fixAccessLevels.dest
                 constructors project.file('constructors.txt')
-                exceptions makeEmptyFile.dest //makeExceptions.dest
-                standardOutput rootProject.NULL_OUTPUT
+                exceptions makeEmptyFileDest //makeExceptions.dest
+                standardOutput NULL_OUTPUT
                 log file(PATH_CACHED_VERSION + s + '.mci.log')
                 input child.rename.dest
                 dest file(PATH_CACHED_VERSION + s + '.mci.jar')
             }
         }
     }
-    task renameJars(dependsOn: [renameClient, renameServer, renameJoined]){}
 
-    task extractInheritance(type: ExtractInheritance, dependsOn: [downloadLibraries, mergeJars]) {
+    tasks.register('renameJars') { dependsOn renameClient, renameServer, renameJoined }
+
+    final File extractInheritanceDest = file(PATH_CACHED_VERSION_DATA + 'inheritance.json')
+    tasks.register('extractInheritance', ExtractInheritance) {
+        dependsOn 'downloadLibraries', mergeJars
         input mergeJars.dest
-        inputs.file downloadJson.dest
-        dest file(PATH_CACHED_VERSION_DATA + 'inheritance.json')
+        inputs.file downloadJsonDest
+        dest extractInheritanceDest
         doFirst {
-            downloadJson.dest.json.libraries.stream().map{ it?.downloads?.artifact?.path }.findAll{ it != null }.each{ library(file(PATH_CACHED_LIBRARIES + it)) }
+            downloadJsonDest.json.libraries.stream().map { it?.downloads?.artifact?.path }.findAll { it !== null }.each { library(file(PATH_CACHED_LIBRARIES + it)) }
         }
     }
-    task extractInheritanceNamed(type: ExtractInheritance, dependsOn: [renameJoined]) {
+    tasks.register('extractInheritanceNamed', ExtractInheritance) {
+        dependsOn renameJoined
         input renameJoined.dest
-        inputs.file downloadJson.dest
+        inputs.file downloadJsonDest
         dest file(PATH_CACHED_VERSION_DATA + 'inheritance_named.json')
         doFirst {
-            downloadJson.dest.json.libraries.stream().map{ it?.downloads?.artifact?.path }.findAll{ it != null }.each{ library(file(PATH_CACHED_LIBRARIES + it)) }
+            downloadJsonDest.json.libraries.stream().map { it?.downloads?.artifact?.path }.findAll { it !== null }.each { library(file(PATH_CACHED_LIBRARIES + it)) }
         }
     }
 
-    task dumpOverrides(type: DumpOverrides, dependsOn: [extractInheritance, makeObfToIntermediate]) {
-        srg makeObfToIntermediate.dest
-        meta extractInheritance.dest
+    tasks.register('dumpOverrides', DumpOverrides) {
+        dependsOn 'extractInheritance', 'makeObfToIntermediate'
+        srg makeObfToIntermediateDest
+        meta extractInheritanceDest
         dest file(PATH_CACHED_VERSION_DATA + 'overrides.txt')
     }
-    
-    task projectRoot(type: Copy) {
+
+    tasks.register('projectRoot', Copy) {
         from rootProject.file('templates/root_settings.gradle')
         into file('projects/')
         rename { 'settings.gradle' }
         expand([version: project.name])
     }
 
-    task extractNatives(type: ExtractNatives, dependsOn: [downloadJson, downloadLibraries]) {
-        meta downloadJson.dest
+    final File extractNativesDest = file(PATH_NATIVES)
+    tasks.register('extractNatives', ExtractNatives) {
+        dependsOn 'downloadJson', 'downloadLibraries', 'downloadRenameTool', 'downloadFernflower',
+                'downloadBundleExtractorLibs', 'downloadBundleExtractorJar', 'downloadMergeTool'
+        meta downloadJsonDest
         cache file(PATH_CACHED_LIBRARIES)
-        dest file(PATH_NATIVES)
+        dest extractNativesDest
     }
-    
-    task verify(type: VerifyMappings, dependsOn: [mergeJars, makeObfToIntermediate]) {
-        mappings = makeObfToIntermediate.dest
+
+    tasks.register('verify', VerifyMappings) {
+        dependsOn mergeJars, 'makeObfToIntermediate'
+        mappings = makeObfToIntermediateDest
         joined = mergeJars.dest
         o2s2idMappings = file('joined.tsrg')
     }
 
-    task decompileAll
-    task projectAll
-    task projectDeleteAll
-    task projectResetAll
-    task projectApplyAll
-    task projectMakeAll
+    tasks.register('decompileAll')
+    tasks.register('projectAll')
+    tasks.register('projectDeleteAll')
+    tasks.register('projectResetAll')
+    tasks.register('projectApplyAll')
+    tasks.register('projectMakeAll')
+
+    tasks.register('testDecompile')
+    tasks.register('testCompile')
+    //tasks.register('testApi')
+    tasks.register('testJdks') {
+        dependsOn 'testDecompile', 'testCompile'//, testApi
+    }
     
-    task testDecompile
-    task testCompile
-    //task testApi
-    task testJdks(dependsOn:[testDecompile, testCompile/*, testApi*/])
-    
-    sides.each{ side, child ->
+    sides.each { String side, def child ->
         // Normal workflow tasks
-        child.decompile = task "decompile${child.Name}"(type: FernflowerTask, dependsOn: [/*verify,*/ downloadFernflower, child.rename, child.libraries] + (MCINJECTOR == null ? [] : [child.mcinject])) {
+        child.decompile = task "decompile${child.Name}"(type: FernflowerTask, dependsOn: [/*verify,*/ 'downloadFernflower', child.rename, child.libraries] + (MCINJECTOR == null ? [] : [child.mcinject])) {
             config FERNFLOWER, downloadFernflower
             libraries = child.libraries.dest
             input = MCINJECTOR != null ? child.mcinject.dest : child.rename.dest
@@ -340,7 +398,9 @@ subprojects {
             dest = file(PATH_CACHED_VERSION + side + '.decompile.jar')
             
         }
-        decompileAll.dependsOn(child.decompile)
+        tasks.named('decompileAll').configure {
+            dependsOn child.decompile
+        }
         
         child.pkgs = task "create${child.Name}PackageInfos"(type: MakePackageInfos, dependsOn: child.decompile) {
             input = child.decompile.dest
@@ -348,7 +408,7 @@ subprojects {
             dest = file(PATH_CACHED_VERSION + side + '.pkgs.jar')
         }
     }
-    
+
     if (MERGE_PATCHES) {
         task deduplicateSources(type: DeduplicateJars, dependsOn: [sides.client.decompile, sides.server.decompile, sides.joined.decompile]) {
             clientIn = sides.client.decompile.dest
@@ -359,23 +419,23 @@ subprojects {
             sides.server.slimsrc = serverOut = file(PATH_CACHED_VERSION + 'server.decompile.slim.jar')
             sides.joined.slimsrc = joinedOut = file(PATH_CACHED_VERSION + 'joined.decompile.slim.jar')
         }
-        
-        task projectSharedMakeDir() {
+
+        tasks.register('projectSharedMakeDir') {
             doLast {
                 mkdir projectSharedReset.target
             }
         }
-        task projectSharedMakePatchesDir() {
+        tasks.register('projectSharedMakePatchesDir') {
             doLast {
                 mkdir projectSharedApplyPatches.patches
             }
         }
-        
-        task projectSharedReset(type: ResetSourcesTask, dependsOn: [deduplicateSources, projectSharedMakeDir]) {
+
+        task projectSharedReset(type: ResetSourcesTask, dependsOn: [deduplicateSources, 'projectSharedMakeDir', 'projectRoot']) {
             rootZip deduplicateSources.duplicates
             target project.file('projects/shared')
         }
-        task projectSharedApplyPatches(type: ApplyPatchesTask, dependsOn: [projectSharedReset, projectSharedMakePatchesDir]) {
+        task projectSharedApplyPatches(type: ApplyPatchesTask, dependsOn: [projectSharedReset, 'projectSharedMakePatchesDir', 'projectRoot']) {
             target projectSharedReset.target
             patches project.file('patches/shared')
         }
@@ -384,26 +444,28 @@ subprojects {
             target projectSharedApplyPatches.target
             patches projectSharedApplyPatches.patches
         }
-        task renameSourcesShared(type: RenameSources, dependsOn: [projectSharedApplyPatches, makeObfToIntermediate, downloadClientMappings]) {
+        task renameSourcesShared(type: RenameSources, dependsOn: [projectSharedApplyPatches, 'makeObfToIntermediate', 'downloadClientMappings']) {
             input = projectSharedApplyPatches.target
-            srg = makeObfToIntermediate.dest
-            official = downloadClientMappings.dest
+            srg = makeObfToIntermediateDest
+            official = downloadClientMappingsDest
             dest = project.file(PATH_CACHED_VERSION + "test/official/shared/src/")
         }
     }
 
-    sides.each{ side, child ->
-        def project_dir = project.file("projects/${side}")
-        def patches_dir = project.file("patches/${side}")
+    sides.each { String side, def child ->
+        final File project_dir = project.file("projects/${side}")
+        final File patches_dir = project.file("patches/${side}")
         
-        child.delete = task "project${child.Name}Delete"(type: Delete) {
+        child.delete = tasks.register("project${child.Name}Delete", Delete) {
             delete project_dir
         }
-        projectDeleteAll.dependsOn(child.delete)
+        tasks.named('projectDeleteAll').configure {
+            dependsOn child.delete
+        }
         
-        child.project = task "project${child.Name}"(type: CreateProjectTemplate, dependsOn: [projectRoot, child.extra, child.decompile, child.pkgs] +
-                (child.jsonlibs ? [downloadJson, extractNatives] : []) +
-                (child.assets ? [downloadAssets] : []) +
+        child.project = task "project${child.Name}"(type: CreateProjectTemplate, dependsOn: ['projectRoot', child.extra, child.decompile, child.pkgs] +
+                (child.jsonlibs ? ['downloadJson', 'extractNatives'] : []) +
+                (child.assets ? ['downloadAssets'] : []) +
                 (child.bundle != null ? [child.bundle] : [])
         ) {
             mustRunAfter child.delete
@@ -411,20 +473,22 @@ subprojects {
             distro side
             template rootProject.file('templates/build.gradle')
             if (child.jsonlibs)
-                meta downloadJson.dest
+                meta downloadJsonDest
             if (child.bundle != null)
                 bundle = child.bundle.dest
             CONFIG?.libraries?.get(side)?.each { library "'${it}'" }
             libraryFile child.extra.extra
             replace '{java_target}', JAVA_TARGET + ''
             replaceFile '{inject}', PATH_INJECT
-            replaceFile '{assets}', child.assets ? downloadAssets.dest : null
-            replaceFile '{natives}', child.jsonlibs ? extractNatives.dest : null
+            replaceFile '{assets}', child.assets ? downloadAssetsDest : null
+            replaceFile '{natives}', child.jsonlibs ? extractNativesDest : null
             replaceFile '{merged_src}', MERGE_PATCHES ? projectSharedReset.target : null
         }
-        projectAll.dependsOn(child.project)
+        tasks.named('projectAll').configure {
+            dependsOn child.project
+        }
 
-        child.makePkgsDir = task "project${child.Name}MakePkgsDir"() {
+        child.makePkgsDir = tasks.register("project${child.Name}MakePkgsDir") {
             doLast {
                 mkdir child.resetPkgs.target
             }
@@ -434,7 +498,7 @@ subprojects {
             rootZip child.pkgs.dest
             target new File(project_dir, 'src/pkginfo/java')
         }
-        child.makeSrcDir = task "project${child.Name}MakeSrcDir"() {
+        child.makeSrcDir = tasks.register("project${child.Name}MakeSrcDir") {
             doLast {
                 mkdir child.reset.target
             }
@@ -444,7 +508,9 @@ subprojects {
             rootZip MERGE_PATCHES ? child.slimsrc : child.decompile.dest
             target new File(project_dir, 'src/main/java')
         }
-        projectResetAll.dependsOn(child.reset)
+        tasks.named('projectResetAll').configure {
+            dependsOn(child.reset)
+        }
         
         child.makePatchesDir = task "project${child.Name}MakePatchesDir"() {
             doLast {
@@ -455,30 +521,40 @@ subprojects {
             target new File(project_dir, 'src/main/java')
             patches patches_dir
         }
-        projectApplyAll.dependsOn(child.apply)
+        tasks.named('projectApplyAll').configure {
+            dependsOn child.apply
+        }
 
         child.makePatches = task "project${child.Name}MakePatches"(type: MakePatchesTask, dependsOn: MERGE_PATCHES ? [deduplicateSources, projectSharedMakePatches] : [child.decompile]) {
             rootZip MERGE_PATCHES ? child.slimsrc : child.decompile.dest
             target new File(project_dir, 'src/main/java')
             patches patches_dir
         }
-        projectMakeAll.dependsOn child.makePatches
+        tasks.named('projectMakeAll').configure {
+            dependsOn child.makePatches
+        }
         
-        child.renameSources = task "renameSources${child.Name}"(type: RenameSources, dependsOn: [child.apply, makeObfToIntermediate, downloadClientMappings] + (MERGE_PATCHES ? [renameSourcesShared] : [])) {
+        child.renameSources = task "renameSources${child.Name}"(type: RenameSources, dependsOn: [child.apply, 'makeObfToIntermediate', 'downloadClientMappings'] + (MERGE_PATCHES ? [renameSourcesShared] : [])) {
             input = new File(project_dir, 'src/main/java')
-            srg = makeObfToIntermediate.dest
-            official = downloadClientMappings.dest
+            srg = makeObfToIntermediateDest
+            official = downloadClientMappingsDest
             dest = project.file(PATH_CACHED_VERSION + "test/official/${side}/src/")
         }
         
         // Tests
         def testDecompileSide = task("testDecompile${child.Name}")
-        testDecompile.dependsOn(testDecompileSide)
+        tasks.named('testDecompile').configure {
+            dependsOn testDecompileSide
+        }
         def testCompileSide = task("testCompile${child.Name}")
-        testCompile.dependsOn(testCompileSide)
+        tasks.named('testCompile').configure {
+            dependsOn testCompileSide
+        }
         /*
         def testApiSide = task("testApi${child.Name}")
-        testApi.dependsOn(testApiSide)
+        tasks.named('testApi').configure {
+            dependsOn testApiSide
+        }
         */
         
         def jdks = [
@@ -497,10 +573,10 @@ subprojects {
             [name: 'official19', Name: 'Official19', version: 19, official: true ],
             [name: 'official20', Name: 'Official20', version: 20, official: true ]
         ]
-        jdks.findAll{ it.version >= JAVA_TARGET }.each{ jdk ->
-            def testPath = project.file(PATH_CACHED_VERSION + 'test/' + jdk.name + '/')
+        jdks.findAll { it.version >= JAVA_TARGET }.each { jdk ->
+            final File testPath = project.file(PATH_CACHED_VERSION + 'test/' + jdk.name + '/')
             
-            def tstDecompile = task "testDecompile${child.Name}${jdk.Name}"(type: FernflowerTask, dependsOn: [downloadFernflower, child.rename, child.libraries]) {
+            def tstDecompile = task "testDecompile${child.Name}${jdk.Name}"(type: FernflowerTask, dependsOn: ['downloadFernflower', child.rename, child.libraries]) {
                 config FERNFLOWER, downloadFernflower
                 javaLauncher = javaToolchains.launcherFor {
                     languageVersion = JavaLanguageVersion.of(jdk.version)
@@ -787,7 +863,7 @@ subprojects {
             }
             timed(MavenPublication) {
                 artifactId rootProject.name
-                version project.version + '-' + rootProject.TIMESTAMP
+                version project.version + '-' + TIMESTAMP
                 artifact makeZip
                 pom {
                     name = 'MCPConfig'

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,13 @@ plugins {
 }
 
 import de.undercouch.gradle.tasks.download.Download
+import groovy.json.JsonBuilder
 import net.minecraftforge.mcpconfig.tasks.*
 import net.minecraftforge.srgutils.MinecraftVersion
+import org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper
 import uk.jamierocks.propatcher.task.*
+
+import java.nio.file.Files
 
 group = 'de.oceanlabs.mcp'
 
@@ -241,28 +245,34 @@ subprojects {
             dest = extractServerLibrariesDest
         }
     }
-    
-    task filterClient(type: SplitJar, dependsOn: 'downloadClient') {
+
+    final File filterClientSlim = file(PATH_CACHED_VERSION + 'client.slim.jar')
+    final File filterClientExtra = file(PATH_CACHED_VERSION + 'client.extra.jar')
+    tasks.register('filterClient', SplitJar) {
+        dependsOn 'downloadClient'
         mappings = file('joined.tsrg')
         source = downloadClientDest
-        slim = file(PATH_CACHED_VERSION + 'client.slim.jar')
-        extra = file(PATH_CACHED_VERSION + 'client.extra.jar')
-    }
-    
-    task filterServer(type: SplitJar, dependsOn: BUNDLE_EXTRACT_JAR == null ? ['downloadServer'] : ['extractServer']) {
-        mappings = file('joined.tsrg')
-        source = BUNDLE_EXTRACT_JAR == null ? downloadServerDest : extractServerDest
-        slim = file(PATH_CACHED_VERSION + 'server.slim.jar')
-        extra = file(PATH_CACHED_VERSION + 'server.extra.jar')
+        slim = filterClientSlim
+        extra = filterClientExtra
     }
 
-    task mergeJars(type: MergeJar, dependsOn: ['downloadMergeTool', filterClient, filterServer]) {
+    final File filterServerSlim = file(PATH_CACHED_VERSION + 'server.slim.jar')
+    final File filterServerExtra = file(PATH_CACHED_VERSION + 'server.extra.jar')
+    tasks.register('filterServer', SplitJar) {
+        dependsOn BUNDLE_EXTRACT_JAR == null ? ['downloadServer'] : ['extractServer']
+        mappings = file('joined.tsrg')
+        source = BUNDLE_EXTRACT_JAR == null ? downloadServerDest : extractServerDest
+        slim = filterServerSlim
+        extra = filterServerExtra
+    }
+
+    task mergeJars(type: MergeJar, dependsOn: ['downloadMergeTool', 'filterClient', filterServer]) {
         config MERGETOOL, tasks.downloadMergeTool
         classpath = configurations.srgutilsJar
         classpath.from project.files(downloadMergeTool)
         mainClass = 'net.minecraftforge.mergetool.ConsoleMerger'
-        client filterClient.slim
-        server filterServer.slim
+        client filterClientSlim
+        server filterServerSlim
         version project.version
         dest file(PATH_CACHED_VERSION + 'joined.jar')
     }
@@ -277,47 +287,57 @@ subprojects {
     }
 
     def sides = [
-        client: [Name: 'Client', jsonlibs: true,  assets: true,  slim: filterClient, extra: filterClient, bundle: null],
-        server: [Name: 'Server', jsonlibs: false, assets: false, slim: filterServer, extra: filterServer, bundle: downloadServer],
-        joined: [Name: 'Joined', jsonlibs: true,  assets: true,  slim: mergeJars,    extra: filterClient, bundle: null]
+        client: [Name: 'Client', jsonlibs: true,  assets: true,  slim: tasks.filterClient, extra: tasks.filterClient, bundle: null],
+        server: [Name: 'Server', jsonlibs: false, assets: false, slim: tasks.filterServer, extra: tasks.filterServer, bundle: downloadServer],
+        joined: [Name: 'Joined', jsonlibs: true,  assets: true,  slim: mergeJars,          extra: tasks.filterClient, bundle: null]
     ]
-    
-    sides.each { String s, def child ->
-        child.libraries = task "fernflowerLibraries${child.Name}"(type: CreateFernflowerLibraries, dependsOn: ['downloadLibraries', 'downloadJson', child.slim] + (BUNDLE_EXTRACT_LIBS == null ? [] : ['extractServerLibraries'])) {
+
+    for (def sidesEntry in sides.entrySet()) {
+        final String s = sidesEntry.key
+        final var child = sidesEntry.value
+
+        child.libraries = tasks.create("fernflowerLibraries${child.Name}", CreateFernflowerLibraries) {
+            dependsOn 'downloadLibraries', 'downloadJson', child.slim
+            if (BUNDLE_EXTRACT_LIBS !== null)
+                dependsOn 'extractServerLibraries'
+
             meta = downloadJsonDest
             config = CONFIG
             side = s
             root = PATH_CACHED_LIBRARIES
             doFirst {
-                if ('server'.equals(s)) {
-                    extras += [filterServer.extra]
+                if (s == 'server') {
+                    extras += [tasks.filterServer.extra]
                     if (BUNDLE_EXTRACT_LIBS != null)
                         extractServerLibrariesDest.eachFileRecurse(groovy.io.FileType.FILES) { file -> extras += [file] }
                 }
             }
-            dest file(PATH_CACHED_VERSION + s + '.fernflower.libs.txt')
+            dest = file(PATH_CACHED_VERSION + s + '.fernflower.libs.txt')
         }
-        
-        child.rename = task "rename${child.Name}"(type: RemapJar, dependsOn: ['downloadRenameTool', child.slim, 'makeObfToIntermediate', child.libraries]) {
+
+        child.renameDest = file(PATH_CACHED_VERSION + s + '.mapped.jar')
+        child.rename = tasks.register("rename${child.Name}", RemapJar) {
+            dependsOn 'downloadRenameTool', child.slim, 'makeObfToIntermediate', child.libraries
             config RENAMETOOL, downloadRenameTool
-            input = 'joined'.equals(s) ? child.slim.dest : child.slim.slim
+            input = s == 'joined' ? child.slim.dest : child.slim.slim
             mappings = makeObfToIntermediateDest
             libraries = child.libraries.dest
-            dest = file(PATH_CACHED_VERSION + s + '.mapped.jar')
+            dest = child.renameDest
             log = file(PATH_CACHED_VERSION + s + '.mapped.log')
         }
-        
+
         if (MCINJECTOR != null) {
             final OutputStream NULL_OUTPUT = new OutputStream() { void write(int b) {} }
-            child.mcinject = task "mcinject${child.Name}"(type: MCInjectTask, dependsOn: ['downloadMCInjector', child.rename, 'makeEmptyFile'/*, makeExceptions, fixAccessLevels*/]) {
+            child.mcinject = tasks.create("mcinject${child.Name}", MCInjectTask) {
+                dependsOn 'downloadMCInjector', child.rename, 'makeEmptyFile'//, makeExceptions, fixAccessLevels
                 config MCINJECTOR, downloadMCInjector
-                access makeEmptyFileDest //fixAccessLevels.dest
-                constructors project.file('constructors.txt')
-                exceptions makeEmptyFileDest //makeExceptions.dest
-                standardOutput NULL_OUTPUT
-                log file(PATH_CACHED_VERSION + s + '.mci.log')
-                input child.rename.dest
-                dest file(PATH_CACHED_VERSION + s + '.mci.jar')
+                access = makeEmptyFileDest //fixAccessLevels.dest
+                constructors = project.file('constructors.txt')
+                exceptions = makeEmptyFileDest //makeExceptions.dest
+                standardOutput = NULL_OUTPUT
+                log = file(PATH_CACHED_VERSION + s + '.mci.log')
+                input = child.renameDest
+                dest = file(PATH_CACHED_VERSION + s + '.mci.jar')
             }
         }
     }
@@ -387,33 +407,43 @@ subprojects {
     tasks.register('testJdks') {
         dependsOn 'testDecompile', 'testCompile'//, testApi
     }
-    
-    sides.each { String side, def child ->
+
+    for (def sidesEntry in sides.entrySet()) {
+        final String side = sidesEntry.key
+        final var child = sidesEntry.value
+
         // Normal workflow tasks
-        child.decompile = task "decompile${child.Name}"(type: FernflowerTask, dependsOn: [/*verify,*/ 'downloadFernflower', child.rename, child.libraries] + (MCINJECTOR == null ? [] : [child.mcinject])) {
+        child.decompileDest = file(PATH_CACHED_VERSION + side + '.decompile.jar')
+        child.decompile = tasks.register("decompile${child.Name}", FernflowerTask) {
+            dependsOn /*verify,*/ 'downloadFernflower', child.rename, child.libraries
+            if (MCINJECTOR !== null)
+                dependsOn child.mcinject
+
             config FERNFLOWER, downloadFernflower
             libraries = child.libraries.dest
-            input = MCINJECTOR != null ? child.mcinject.dest : child.rename.dest
+            input = MCINJECTOR != null ? child.mcinject.dest : child.renameDest
             log = file(PATH_CACHED_VERSION + side + '.decompile.log')
-            dest = file(PATH_CACHED_VERSION + side + '.decompile.jar')
-            
+            dest = child.decompileDest
+
         }
         tasks.named('decompileAll').configure {
             dependsOn child.decompile
         }
-        
-        child.pkgs = task "create${child.Name}PackageInfos"(type: MakePackageInfos, dependsOn: child.decompile) {
-            input = child.decompile.dest
+
+        child.pkgsDest = file(PATH_CACHED_VERSION + side + '.pkgs.jar')
+        child.pkgs = tasks.register("create${child.Name}PackageInfos", MakePackageInfos) {
+            dependsOn child.decompile
+            input = child.decompileDest
             template = PATH_INJECT_TEMPLATE.exists() ? PATH_INJECT_TEMPLATE : null
-            dest = file(PATH_CACHED_VERSION + side + '.pkgs.jar')
+            dest = child.pkgsDest
         }
     }
 
     if (MERGE_PATCHES) {
         task deduplicateSources(type: DeduplicateJars, dependsOn: [sides.client.decompile, sides.server.decompile, sides.joined.decompile]) {
-            clientIn = sides.client.decompile.dest
-            serverIn = sides.server.decompile.dest
-            joinedIn = sides.joined.decompile.dest
+            clientIn = sides.client.decompileDest
+            serverIn = sides.server.decompileDest
+            joinedIn = sides.joined.decompileDest
             duplicates = file(PATH_CACHED_VERSION + 'source.duplicates.jar')
             sides.client.slimsrc = clientOut = file(PATH_CACHED_VERSION + 'client.decompile.slim.jar')
             sides.server.slimsrc = serverOut = file(PATH_CACHED_VERSION + 'server.decompile.slim.jar')
@@ -452,7 +482,10 @@ subprojects {
         }
     }
 
-    sides.each { String side, def child ->
+    for (def sidesEntry in sides.entrySet()) {
+        final String side = sidesEntry.key
+        final var child = sidesEntry.value
+
         final File project_dir = project.file("projects/${side}")
         final File patches_dir = project.file("patches/${side}")
         
@@ -488,36 +521,50 @@ subprojects {
             dependsOn child.project
         }
 
+        final File resetPkgsTarget = new File(project_dir, 'src/pkginfo/java')
+        child.resetPkgs = tasks.register("project${child.Name}ResetPackages", ResetSourcesTask) {
+            dependsOn child.makePkgsDir, child.pkgs
+            mustRunAfter child.project
+            rootZip child.pkgsDest
+            target resetPkgsTarget
+        }
         child.makePkgsDir = tasks.register("project${child.Name}MakePkgsDir") {
             doLast {
-                mkdir child.resetPkgs.target
+                mkdir resetPkgsTarget
             }
         }
-        child.resetPkgs = task "project${child.Name}ResetPackages"(type: ResetSourcesTask, dependsOn: [child.makePkgsDir, child.pkgs]) {
+
+        final File resetTarget = new File(project_dir, 'src/main/java')
+        child.reset = tasks.register("project${child.Name}Reset", ResetSourcesTask) {
+            dependsOn child.resetPkgs, child.makeSrcDir, child.project, child.decompile
+            if (MERGE_PATCHES)
+                dependsOn projectSharedReset
+
             mustRunAfter child.project
-            rootZip child.pkgs.dest
-            target new File(project_dir, 'src/pkginfo/java')
+            rootZip MERGE_PATCHES ? child.slimsrc : child.decompileDest
+            target resetTarget
         }
         child.makeSrcDir = tasks.register("project${child.Name}MakeSrcDir") {
             doLast {
-                mkdir child.reset.target
+                mkdir resetTarget
             }
         }
-        child.reset = task "project${child.Name}Reset"(type: ResetSourcesTask, dependsOn: [child.resetPkgs, child.makeSrcDir, child.project, child.decompile] + (MERGE_PATCHES ? [projectSharedReset] : [])) {
-            mustRunAfter child.project
-            rootZip MERGE_PATCHES ? child.slimsrc : child.decompile.dest
-            target new File(project_dir, 'src/main/java')
-        }
+
         tasks.named('projectResetAll').configure {
-            dependsOn(child.reset)
+            dependsOn child.reset
         }
         
-        child.makePatchesDir = task "project${child.Name}MakePatchesDir"() {
+        child.makePatchesDir = tasks.register("project${child.Name}MakePatchesDir") {
             doLast {
                 mkdir patches_dir
             }
         }
-        child.apply = task "project${child.Name}ApplyPatches"(type: ApplyPatchesTask, dependsOn: [child.reset, child.makePatchesDir] + (MERGE_PATCHES ? [projectSharedApplyPatches] : [])) {
+
+        child.apply = tasks.register("project${child.Name}ApplyPatches", ApplyPatchesTask) {
+            dependsOn child.reset, child.makePatchesDir
+            if (MERGE_PATCHES)
+                dependsOn projectSharedApplyPatches
+
             target new File(project_dir, 'src/main/java')
             patches patches_dir
         }
@@ -525,28 +572,39 @@ subprojects {
             dependsOn child.apply
         }
 
-        child.makePatches = task "project${child.Name}MakePatches"(type: MakePatchesTask, dependsOn: MERGE_PATCHES ? [deduplicateSources, projectSharedMakePatches] : [child.decompile]) {
-            rootZip MERGE_PATCHES ? child.slimsrc : child.decompile.dest
+        child.makePatches = tasks.register("project${child.Name}MakePatches", MakePatchesTask) {
+            if (MERGE_PATCHES)
+                dependsOn deduplicateSources, projectSharedMakePatches
+            else
+                dependsOn child.decompile
+
+            rootZip MERGE_PATCHES ? child.slimsrc : child.decompileDest
             target new File(project_dir, 'src/main/java')
             patches patches_dir
         }
         tasks.named('projectMakeAll').configure {
             dependsOn child.makePatches
         }
-        
-        child.renameSources = task "renameSources${child.Name}"(type: RenameSources, dependsOn: [child.apply, 'makeObfToIntermediate', 'downloadClientMappings'] + (MERGE_PATCHES ? [renameSourcesShared] : [])) {
-            input = new File(project_dir, 'src/main/java')
+
+        child.renameSourcesInput = new File(project_dir, 'src/main/java')
+        child.renameSourcesDest = project.file(PATH_CACHED_VERSION + "test/official/${side}/src/")
+        child.renameSources = tasks.register("renameSources${child.Name}", RenameSources) {
+            dependsOn child.apply, 'makeObfToIntermediate', 'downloadClientMappings'
+            if (MERGE_PATCHES)
+                dependsOn renameSourcesShared
+
+            input = child.renameSourcesInput
             srg = makeObfToIntermediateDest
             official = downloadClientMappingsDest
-            dest = project.file(PATH_CACHED_VERSION + "test/official/${side}/src/")
+            dest = child.renameSourcesDest
         }
         
         // Tests
-        def testDecompileSide = task("testDecompile${child.Name}")
+        final TaskProvider<Task> testDecompileSide = tasks.register("testDecompile${child.Name}")
         tasks.named('testDecompile').configure {
             dependsOn testDecompileSide
         }
-        def testCompileSide = task("testCompile${child.Name}")
+        final TaskProvider<Task> testCompileSide = tasks.register("testCompile${child.Name}")
         tasks.named('testCompile').configure {
             dependsOn testCompileSide
         }
@@ -575,38 +633,48 @@ subprojects {
         ]
         jdks.findAll { it.version >= JAVA_TARGET }.each { jdk ->
             final File testPath = project.file(PATH_CACHED_VERSION + 'test/' + jdk.name + '/')
-            
-            def tstDecompile = task "testDecompile${child.Name}${jdk.Name}"(type: FernflowerTask, dependsOn: ['downloadFernflower', child.rename, child.libraries]) {
+
+            final File tstDecompileDest = new File(testPath, side + '.decompile.jar')
+            var tstDecompile = tasks.register("testDecompile${child.Name}${jdk.Name}", FernflowerTask) {
+                dependsOn 'downloadFernflower', child.rename, child.libraries
                 config FERNFLOWER, downloadFernflower
                 javaLauncher = javaToolchains.launcherFor {
                     languageVersion = JavaLanguageVersion.of(jdk.version)
                 }
                 libraries = child.libraries.dest
-                input = child.rename.dest
+                input = child.renameDest
                 log = new File(testPath, side + '.decompile.log')
-                dest = new File(testPath, side + '.decompile.jar')
-                
+                dest = tstDecompileDest
             }
-            def tstDecompileCheck = task "testDecompile${child.Name}${jdk.Name}Compare"(type: CompareJars, dependsOn: [tstDecompile, child.decompile]) {
-                expected = child.decompile.dest
-                actual = tstDecompile.dest
+
+            var tstDecompileCheck = tasks.register("testDecompile${child.Name}${jdk.Name}Compare", CompareJars) {
+                dependsOn tstDecompile, child.decompile
+                expected = child.decompileDest
+                actual = tstDecompileDest
             }
-            testDecompileSide.dependsOn(tstDecompileCheck)
+            testDecompileSide.configure {
+                dependsOn tstDecompileCheck
+            }
             
-            def tstCompileClean = task "testCompile${child.Name}${jdk.Name}Clean"(type: Delete) {
+            var tstCompileClean = tasks.register("testCompile${child.Name}${jdk.Name}Clean", Delete) {
                 delete new File(testPath, 'classes')
             }
             
-            def sourceDir = jdk.official ? child.renameSources.dest : child.renameSources.input
+            File sourceDir = jdk.official ? child.renameSourcesDest : child.renameSourcesInput
             def sharedDir = MERGE_PATCHES ? (jdk.official ? renameSourcesShared.dest : renameSourcesShared.input) : null
             
-            def tstCompile = task "testCompile${child.Name}${jdk.Name}"(type: JavaCompile, dependsOn: [child.apply, tstCompileClean] + (jdk.official ? [child.renameSources] : [])) {
+            var tstCompile = tasks.register("testCompile${child.Name}${jdk.Name}", JavaCompile) {
+                dependsOn child.apply, tstCompileClean
+                if (jdk.official)
+                    dependsOn child.renameSources
+
                 javaCompiler = javaToolchains.compilerFor {
                     languageVersion = JavaLanguageVersion.of(jdk.version)
                 }
                 source = project.files(sourceDir)
-                if (sharedDir != null)
+                if (sharedDir !== null)
                     source += project.files(sharedDir)
+
                 destinationDirectory = new File(testPath, 'classes')
                 options.warnings = false
                 options.encoding = ENCODING
@@ -614,12 +682,14 @@ subprojects {
                 // JavaCompile task type requires classpath to be specified before the task begins execution
                 // but the data isn't generated yet, so instead - inject the classpath as the first thing done when it begins
                 classpath = files()
-                getOptions().setFork(true)
+                options.fork = true
                 doFirst {
-                    classpath = files(java.nio.file.Files.readAllLines(child.libraries.dest.toPath()).collect { file(it.substring(3)) }) // skip "-e="
+                    classpath = files(Files.readAllLines(child.libraries.dest.toPath()).collect { file(it.substring(3)) }) // skip "-e="
                 }
             }
-            testCompileSide.dependsOn(tstCompile)
+            testCompileSide.configure {
+                dependsOn tstCompile
+            }
             
             /*
             def tstApi = task "testApi${child.Name}${jdk.Name}"(type: CheckAPI, dependsOn: [tstCompile, rootProject.extractRuntimeApi]) {
@@ -632,15 +702,15 @@ subprojects {
         }
     }
 
-    task generateConfiguration(type: SingleFileOutput) {
+    tasks.register('generateConfiguration', SingleFileOutput) {
         inputs.property('config', CONFIG)
         dest file(PATH_CACHED_VERSION_DATA + 'config.json')
 
         doLast {
-            def json = new groovy.json.JsonBuilder()
-            
+            var json = new JsonBuilder()
+
             if (CONFIG.official) {
-                def steps_def = [
+                var steps_def = [
                     joined: [
                         [type: 'downloadManifest'],
                         [type: 'downloadJson'],
@@ -684,20 +754,22 @@ subprojects {
                         [type: 'patch', input: '{injectOutput}']
                     ]
                 ]
-                def functions_def = [
-                    decompile: FERNFLOWER.findAll {it.key != 'path'},
-                    merge:     MERGETOOL .findAll {it.key != 'path'},
-                    rename:    RENAMETOOL.findAll {it.key != 'path'},
-                    mergeMappings: MERGEMAPTOOL.findAll {it.key != 'path'}
+
+                final Closure<Boolean> keyIsNotPath = { it.key != 'path' }
+                Map<String, Collection> functions_def = [
+                    decompile: FERNFLOWER.findAll(keyIsNotPath),
+                    merge:     MERGETOOL .findAll(keyIsNotPath),
+                    rename:    RENAMETOOL.findAll(keyIsNotPath),
+                    mergeMappings: MERGEMAPTOOL.findAll(keyIsNotPath)
                 ]
-                def specVer = 2
-                
+                int specVer = 2
+
                 if (BUNDLE_EXTRACT_JAR != null) {
                     specVer = 3 // Spec v3 adds 'bundle' to the listLibraries task. 
                     functions_def['bundleExtractJar'] = BUNDLE_EXTRACT_JAR.findAll {it.key != 'path'}
                     steps_def['joined'].add(4, [name: 'extractServer', type: 'bundleExtractJar', input: '{downloadServerOutput}'])
                     steps_def['joined'].find{'stripServer'.equals(it.name) }['input'] = '{extractServerOutput}'
-                    
+
                     steps_def['server'].add(3, [name: 'extractServer', type: 'bundleExtractJar', input: '{downloadServerOutput}'])
                     steps_def['server'].find{'strip'.equals(it.type) }['input'] = '{extractServerOutput}'
                     steps_def['server'].find{'listLibraries'.equals(it.type) }['bundle'] = '{downloadServerOutput}'
@@ -706,7 +778,7 @@ subprojects {
                 if (functions_def.values().any { it.java_version != null }) {
                     specVer = 4 // Spec v4 adds the ability to set a java version to run a tool with
                 }
-                
+
                 json {
                     spec specVer
                     version project.version
@@ -798,17 +870,17 @@ subprojects {
         }
     }
 
-    task makeZip(type: Zip, dependsOn: [generateConfiguration]) {
+    task makeZip(type: Zip, dependsOn: ['generateConfiguration']) {
         archiveBaseName = rootProject.name
         archiveVersion = project.version
         destinationDirectory = file(PATH_BUILD + '/distributions')
 
-        from generateConfiguration
+        from tasks.generateConfiguration
         from(file('joined.tsrg')){ into 'config/' }
 
-        def patches = file('patches')
+        var patches = file('patches')
         if (patches.exists()) {
-            def shared = file('patches/shared')
+            var shared = file('patches/shared')
             if (MERGE_PATCHES && shared.exists()) {
                 for (def side : ['client', 'server', 'joined']) {
                     from(file('patches/' + side)) {
@@ -835,7 +907,7 @@ subprojects {
     publishing {
         publications {
             if (!rootProject.hasProperty('timed_only') && (MC_VERSION.compareTo(MC_1_16_5) > 0 || !CONFIG.official)) {
-                normal(MavenPublication) {
+                register('normal', MavenPublication) {
                     artifactId rootProject.name
                     artifact makeZip
                     pom {
@@ -861,7 +933,7 @@ subprojects {
                     }
                 }
             }
-            timed(MavenPublication) {
+            register('timed', MavenPublication) {
                 artifactId rootProject.name
                 version project.version + '-' + TIMESTAMP
                 artifact makeZip
@@ -907,7 +979,7 @@ subprojects {
     }
 }
 
-def getVersionIndex(prop, default_) {
+int getVersionIndex(String prop, int default_) {
     if (!project.hasProperty(prop))
         return default_
     if (!VERSIONS.contains(project.getProperty(prop)))
@@ -915,19 +987,26 @@ def getVersionIndex(prop, default_) {
     return VERSIONS.indexOf(project.getProperty(prop))
 }
 
-def template = project(':' + VERSIONS[0])
-def start = getVersionIndex('startVersion', 0)
-def end = getVersionIndex('endVersion', VERSIONS.size - 1)
+var template = project(':' + VERSIONS[0])
+final int start = getVersionIndex('startVersion', 0)
+final int end = getVersionIndex('endVersion', VERSIONS.size - 1)
 
 if (start > end)
     throw new IllegalArgumentException('Invalid start and end range: ' + VERSIONS[start] + ' > ' + VERSIONS[end])
 
-template.tasks.each{t ->
-    def myTask = project.tasks.findByName(t.name) ?: project.tasks.create(t.name)
+template.tasks.each { t ->
+    var myTask
+    try {
+        myTask = tasks.named(t.name)
+    } catch (UnknownTaskException ignored) {
+        myTask = tasks.register(t.name)
+    }
     for (int x = start; x <= end; x++) {
-        def task = project(VERSIONS[x]).tasks.findByName(t.name)
-        if (task != null)
-            myTask.dependsOn task
+        try {
+            var task = project(VERSIONS[x]).tasks.named(t.name)
+            myTask.configure {
+                dependsOn task
+            }
+        } catch (UnknownTaskException ignored) {}
     }
 }
-

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'org.ow2.asm:asm-tree:9.2'
     implementation 'net.minecraftforge:srgutils:0.5.3'
     implementation 'org.tukaani:xz:1.8' // Extract API, to extract the runtime jars, as Mojang uses lzma
-    implementation 'de.undercouch:gradle-download-task:4.1.1' // Bulk DownloadLibraries task
+    implementation 'de.undercouch:gradle-download-task:5.5.0' // Bulk DownloadLibraries task
     implementation 'net.minecraftforge:mapping-verifier:2.0.8'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4' // Needed for verifier
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CompareJars.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CompareJars.groovy
@@ -55,7 +55,7 @@ public class CompareJars extends DefaultTask {
             throw new GradleException("Comparison failed, see log for details")
     }
     
-    def loadJar(jar) {
+    static def loadJar(jar) {
         def ret = [:]
         new ZipFile(jar).withCloseable{ jin -> 
             jin.entries().each { entry ->

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateProjectTemplate.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/CreateProjectTemplate.groovy
@@ -62,7 +62,7 @@ public class CreateProjectTemplate extends DefaultTask {
         
         if (bundle != null) {
             def zf = new ZipFile(bundle)
-            zf.entries().findAll{ it.name.equals('META-INF/libraries.list') }.each {
+            zf.entries().findAll { it.name == 'META-INF/libraries.list' }.each {
                 zf.getInputStream(it).text.split('\r?\n').each { line -> 
                     libs.add("'" + line.split('\t')[1] + "'")
                 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DeduplicateJars.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DeduplicateJars.groovy
@@ -32,7 +32,7 @@ public class DeduplicateJars extends DefaultTask {
             joined: joinedOut
         ]
         
-        def dupes = []
+        List dupes = []
         
         new ZipOutputStream(duplicates.newOutputStream()).withCloseable{ du ->
             inputs.client.each { name, data ->

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DownloadAssets.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DownloadAssets.groovy
@@ -13,7 +13,7 @@ public class DownloadAssets extends DefaultTask {
         Utils.init()
         
         def dl = json.json.assetIndex
-        def index = new File(dest, 'indexes/' + dl.id + '.json')
+        File index = new File(dest, 'indexes/' + dl.id + '.json')
         if (index.sha1 != dl.sha1)
             download(dl.url, index)
         
@@ -25,7 +25,7 @@ public class DownloadAssets extends DefaultTask {
         }
     }
 
-    def download(def url, def target) {
+    def download(String url, File target) {
         def ret = new DownloadAction(project, this)
         ret.overwrite(false)
         ret.useETag('all')

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DownloadTool.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DownloadTool.groovy
@@ -13,7 +13,7 @@ public class DownloadTool extends Download {
         quiet true
     }
     
-    def config(def cfg, def root) {
+    def config(def cfg, String root) {
         this.config = cfg
         src cfg.repo + cfg.path
         dest new File(root + cfg.path)

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DownloadTool.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/DownloadTool.groovy
@@ -1,13 +1,12 @@
 package net.minecraftforge.mcpconfig.tasks
 
-import org.gradle.api.*
 import org.gradle.api.tasks.*
 import de.undercouch.gradle.tasks.download.Download
 
-public class DownloadTool extends Download {
+class DownloadTool extends Download {
     @Input config
     
-    public DownloadTool() {
+    DownloadTool() {
         useETag 'all'
         onlyIfModified true
         quiet true

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/FernflowerTask.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/FernflowerTask.groovy
@@ -3,7 +3,7 @@ package net.minecraftforge.mcpconfig.tasks
 import org.gradle.api.tasks.*
 import java.util.zip.*
 
-public class FernflowerTask extends ToolJarExec {
+class FernflowerTask extends ToolJarExec {
     @InputFile File libraries
     @InputFile File input
     @OutputFile File log
@@ -11,9 +11,9 @@ public class FernflowerTask extends ToolJarExec {
     
     @Override
     protected void preExec() {
-        def logStream = log.newOutputStream()
-        standardOutput logStream
-        errorOutput logStream
+        var logStream = log.newOutputStream()
+        standardOutput = logStream
+        errorOutput = logStream
         setArgs(Utils.fillVariables(args, [
             'libraries': libraries,
             'input': input,
@@ -25,17 +25,17 @@ public class FernflowerTask extends ToolJarExec {
     protected void postExec() {
         if (!dest.exists())
             throw new IllegalStateException('Could not find fernflower output: ' + dest)
-        def failed = []
-        new ZipFile(dest).withCloseable{ zip -> 
-            zip.entries().findAll{ !it.directory && it.name.endsWith('.java') }.each { e ->
-                def data = zip.getInputStream(e).text
+        List<String> failed = []
+        new ZipFile(dest).withCloseable { zip ->
+            zip.entries().findAll { !it.directory && it.name.endsWith('.java') }.each { e ->
+                String data = zip.getInputStream(e).text
                 if (data.isEmpty() || data.contains("\$FF: Couldn't be decompiled"))
                     failed.add(e.name)
             }
         }
         if (!failed.isEmpty()) {
             logger.lifecycle('Failed to decompile: ')
-            failed.each{ logger.lifecycle('  ' + it) }
+            failed.each { logger.lifecycle('  ' + it) }
             throw new IllegalStateException('Decompile failed')
         }
     }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/MergeJar.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/MergeJar.groovy
@@ -1,6 +1,5 @@
 package net.minecraftforge.mcpconfig.tasks;
 
-import org.gradle.api.*
 import org.gradle.api.tasks.*
 
 class MergeJar extends ToolJarExec {

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RemapJar.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RemapJar.groovy
@@ -12,7 +12,7 @@ class RemapJar extends ToolJarExec {
     
     @Override
     protected void preExec() {
-        def logStream = log == null ? JarExec.NULL_OUTPUT : log.newOutputStream()
+        def logStream = log === null ? JarExec.NULL_OUTPUT : log.newOutputStream()
         standardOutput logStream
         errorOutput logStream
         setArgs(Utils.fillVariables(args, [

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RemapJar.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RemapJar.groovy
@@ -1,6 +1,5 @@
 package net.minecraftforge.mcpconfig.tasks;
 
-import org.gradle.api.*
 import org.gradle.api.tasks.*
 
 class RemapJar extends ToolJarExec {
@@ -12,9 +11,9 @@ class RemapJar extends ToolJarExec {
     
     @Override
     protected void preExec() {
-        def logStream = log === null ? JarExec.NULL_OUTPUT : log.newOutputStream()
-        standardOutput logStream
-        errorOutput logStream
+        var logStream = log === null ? JarExec.NULL_OUTPUT : log.newOutputStream()
+        standardOutput = logStream
+        errorOutput = logStream
         setArgs(Utils.fillVariables(args, [
             'mappings': mappings.absolutePath,
             'input': input.absolutePath,

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RenameMappings.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RenameMappings.groovy
@@ -12,7 +12,7 @@ public class RenameMappings extends SingleFileOutput {
     @InputFile @Optional official
     
     @TaskAction
-    def exec() {
+    void exec() {
         Utils.init()
         def ret
         if (official != null) {

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RenameSources.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/RenameSources.groovy
@@ -51,11 +51,11 @@ public class RenameSources extends DefaultTask {
             def ocls = moff.getClass(scls.original)
             if (ocls != null) {
                 scls.fields.each{ sfld ->
-                    if (sfld.mapped.startsWith('f_') || sfld.mapped.startsWith('field_'))
+                    if (sfld.mapped.startsWithAny('f_', 'field_'))
                         ret.put(sfld.mapped, ocls.remapField(sfld.original))
                 }
                 scls.methods.each{ smtd ->
-                    if (smtd.mapped.startsWith('m_') || smtd.mapped.startsWith('func_'))
+                    if (smtd.mapped.startsWithAny('m_', 'func_'))
                         ret.put(smtd.mapped, ocls.remapMethod(smtd.original, smtd.descriptor))
                 }
             }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/SingleFileOutput.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/SingleFileOutput.groovy
@@ -5,5 +5,5 @@ import org.gradle.api.tasks.*
 
 //Small helper base task that only outputs one file, this is useful so I can jsut do task.dest instead of task.outputs.files.singleFile 
 class SingleFileOutput extends DefaultTask {
-    @OutputFile File dest //dest is used to be consistant with the download plugin's Download task
+    @OutputFile File dest //dest is used to be consistent with the download plugin's Download task
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/SplitJar.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/SplitJar.groovy
@@ -10,8 +10,8 @@ import net.minecraftforge.srgutils.IMappingFile
 public class SplitJar extends DefaultTask {
     @InputFile mappings
     @InputFile source
-    @OutputFile slim
-    @OutputFile extra
+    @OutputFile File slim
+    @OutputFile File extra
     
     @TaskAction
     def exec() {

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ToolJarExec.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ToolJarExec.groovy
@@ -1,5 +1,6 @@
-package net.minecraftforge.mcpconfig.tasks;
+package net.minecraftforge.mcpconfig.tasks
 
+import de.undercouch.gradle.tasks.download.Download;
 import org.gradle.api.tasks.*
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
@@ -7,7 +8,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 import javax.inject.Inject
 
 class ToolJarExec extends JavaExec {
-    def config(def cfg, def task) {
+    void config(def cfg, Download task) {
         classpath = project.files(task.dest)
         args = cfg.args
         jvmArgs = cfg.jvmargs

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ToolJarExec.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/ToolJarExec.groovy
@@ -35,12 +35,12 @@ class ToolJarExec extends JavaExec {
     }
 
     @Override
-    public final void exec() {
+    final void exec() {
         this.preExec()
         super.exec()
         this.postExec()
     }
     
-    protected void preExec(){}
-    protected void postExec(){}
+    protected void preExec() {}
+    protected void postExec() {}
 }

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/Utils.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/Utils.groovy
@@ -1,4 +1,6 @@
-package net.minecraftforge.mcpconfig.tasks;
+package net.minecraftforge.mcpconfig.tasks
+
+import groovy.transform.CompileStatic;
 
 import java.util.*
 import java.util.regex.Matcher
@@ -60,9 +62,10 @@ class Utils {
         }
         return allow
     }
-    
-    static def getOsName() {
-        def name = System.getProperty('os.name').toLowerCase(java.util.Locale.ENGLISH)
+
+    @CompileStatic
+    static String getOsName() {
+        String name = System.getProperty('os.name').toLowerCase(Locale.ENGLISH)
         if (name.contains('windows') || name.contains('win')) return 'windows'
         if (name.contains('linux') || name.contains('unix')) return 'linux'
         if (name.contains('osx') || name.contains('mac')) return 'osx'

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/VerifyMappings.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/VerifyMappings.groovy
@@ -25,7 +25,7 @@ public class VerifyMappings extends DefaultTask {
         mv.loadJar(joined)
         mv.addDefaultTasks()
 
-        def die = false
+        boolean die = false
         if (!mv.verify()) {
             for (def t : mv.tasks) {
                 if (!t.errors.isEmpty()) {

--- a/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/VerifyMappings.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/mcpconfig/tasks/VerifyMappings.groovy
@@ -11,13 +11,13 @@ import java.util.function.Predicate
 
 import net.minecraftforge.mappingverifier.MappingVerifier
 
-public class VerifyMappings extends DefaultTask {
-    @InputFile mappings
-    @InputFile joined
-    @InputFile o2s2idMappings
+class VerifyMappings extends DefaultTask {
+    @InputFile File mappings
+    @InputFile File joined
+    @InputFile File o2s2idMappings
     
     @TaskAction
-    def exec() {
+    void exec() {
         Utils.init()
 
         MappingVerifier mv = new MappingVerifier()
@@ -118,7 +118,7 @@ public class VerifyMappings extends DefaultTask {
                     unique.add(id)
             }
 
-            duplicates.each {s -> error('Id ' + s + ' is a duplicate.')}
+            duplicates.each { s -> error('Id ' + s + ' is a duplicate.')}
 
             return superProcess && duplicates.isEmpty()
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,35 +2,38 @@ rootProject.name = 'mcp_config'
 
 ext.versions = [] as Set
 
-def addDirectory(path) {
+void addDirectory(File path) {
     path.eachDir() {
-        def relative = rootDir.toPath().relativize(it.toPath()).toFile()
+        File relative = rootDir.toPath().relativize(it.toPath()).toFile()
         include relative.path
         project(':' + relative.path).name = it.name
         versions.add(it.name)
     }
 }
 
-def type = hasProperty('type') ? getProperty('type').toLowerCase() : 'release'
-
-if ('release'.equals(type)) {
-    addDirectory(new File(rootDir, 'versions/release/'))
-} else if ('snapshot'.equals(type)) {
-    if (hasProperty('ver')) {
-        addDirectory(new File(rootDir, 'versions/snapshot/' + getProperty('ver')))
-    } else {
-        new File(rootDir, 'versions/snapshot/').eachDir() {
-            addDirectory(it)
+final String type = hasProperty('type') ? getProperty('type').toLowerCase() : 'release'
+switch (type) {
+    case 'release':
+        addDirectory(new File(rootDir, 'versions/release/'))
+        break
+    case 'snapshot':
+        if (hasProperty('ver')) {
+            addDirectory(new File(rootDir, 'versions/snapshot/' + getProperty('ver')))
+        } else {
+            new File(rootDir, 'versions/snapshot/').eachDir() {
+                addDirectory(it)
+            }
         }
-    }
-} else if ('pre'.equals(type)) {
-    if (hasProperty('ver')) {
-        addDirectory(new File(rootDir, 'versions/pre/' + getProperty('ver')))
-    } else {
-        new File(rootDir, 'versions/pre/').eachDir() {
-            addDirectory(it)
+        break
+    case 'pre':
+        if (hasProperty('ver')) {
+            addDirectory(new File(rootDir, 'versions/pre/' + getProperty('ver')))
+        } else {
+            new File(rootDir, 'versions/pre/').eachDir() {
+                addDirectory(it)
+            }
         }
-    }
+        break
 }
 
 println('Versions: ' + versions)


### PR DESCRIPTION
Unfortunately doesn't allow us to enable the configuration cache for full parallel execution of independent tasks within the same sub-project (such as the different JDKs in the testJdks task), but does speed up the configuration stage and improve IDE support nonetheless.