### PR TITLE
feat: Add 26.3-snapshot-2 config and patches

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'com.google.guava:guava:25.1-jre'
     implementation 'org.ow2.asm:asm:9.9.1'
     implementation 'org.ow2.asm:asm-tree:9.9.1'
-    implementation 'net.minecraftforge:srgutils:0.6.2'
+    implementation 'net.minecraftforge:srgutils:0.6.6'
     implementation 'org.tukaani:xz:1.8' // Extract API, to extract the runtime jars, as Mojang uses lzma
     implementation 'de.undercouch:gradle-download-task:4.1.1' // Bulk DownloadLibraries task
     implementation 'net.minecraftforge:mapping-verifier:2.1.3'

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,5 @@
+includeBuild('../../SrgUtils') {
+    dependencySubstitution {
+        substitute module('net.minecraftforge:srgutils') using project(':')
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,12 @@ plugins {
 
 rootProject.name = 'mcp_config'
 
+includeBuild('../SrgUtils') {
+    dependencySubstitution {
+        substitute module('net.minecraftforge:srgutils') using project(':')
+    }
+}
+
 ext.versions = [] as Set
 
 def addDirectory(path) {

--- a/update.gradle
+++ b/update.gradle
@@ -6,6 +6,14 @@ repositories {
     maven { url = 'https://maven.minecraftforge.net/'}
 }
 
+configurations {
+    mappingToyClasspath
+}
+
+dependencies {
+    mappingToyClasspath 'net.minecraftforge:srgutils:0.6.6'
+}
+
 ext {
     OLD_VERSION = project.getProperty('old_version').replace('\\', '/')
     OLD_PATH = 'versions/release/' + OLD_VERSION + '/'
@@ -32,6 +40,7 @@ task downloadMappingToy(type: Download) {
 }
 
 task runMappingToy(type: JavaExec, dependsOn: downloadMappingToy) {
+    classpath.from configurations.mappingToyClasspath
     classpath.from files(downloadMappingToy.dest)
     mainClass = 'net.minecraftforge.lex.mappingtoy.MappingToy'
     args = ['--libs', '--output', MAP_DATA, '--version', OLD_VERSION, '--version', NEW_VERSION]

--- a/versions/pre/26/26.3-snapshot-2/config.json
+++ b/versions/pre/26/26.3-snapshot-2/config.json
@@ -1,0 +1,31 @@
+{
+    "official": true,
+    "obfuscated": false,
+    "inject": false,
+    "merge_patches": true,
+    "java_target": 25,
+    "encoding": "UTF-8",
+    "fernflower": {
+        "version": "org.vineflower:vineflower:1.12.0",
+        "java_version": 25,
+        "args": ["--decompile-inner", "--remove-bridge", "--decompile-generics", "--ascii-strings", "--remove-synthetic", "--include-classpath", "--ignore-invalid-bytecode", "--bytecode-source-mapping", "--dump-code-lines", "--indent-string=    ", "--log-level=TRACE", "-cfg", "{libraries}", "{input}", "{output}"]
+    },
+    "merge": {
+        "version": "net.minecraftforge:mergetool:1.2.5:fatjar",
+        "args": ["--client", "{client}", "--server", "{server}", "--ann", "{version}", "--output", "{output}", "--inject", "false", "--keep-data"],
+        "jvmargs": []
+    },
+    "bundler_extract_jar": {
+        "version": "net.minecraftforge:installertools:1.3.2:fatjar",
+        "args": ["--task", "bundler_extract", "--input", "{input}", "--output", "{output}", "--jar-only"]
+    },
+    "bundler_extract_libs": {
+        "version": "net.minecraftforge:installertools:1.3.2:fatjar",
+        "args": ["--task", "bundler_extract", "--input", "{input}", "--output", "{output}", "--libraries"]
+    },
+    "libraries": {
+        "client": ["com.google.code.findbugs:jsr305:3.0.2", "org.jetbrains:annotations:24.0.1", "ca.weblite:java-objc-bridge:1.1"],
+        "server": ["com.google.code.findbugs:jsr305:3.0.2", "org.jetbrains:annotations:24.0.1"],
+        "joined": ["com.google.code.findbugs:jsr305:3.0.2", "org.jetbrains:annotations:24.0.1", "ca.weblite:java-objc-bridge:1.1", "net.minecraftforge:mergetool-api:1.0"]
+    }
+}

--- a/versions/pre/26/26.3-snapshot-2/inject/mcp/client/Start.java
+++ b/versions/pre/26/26.3-snapshot-2/inject/mcp/client/Start.java
@@ -1,0 +1,94 @@
+package mcp.client;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
+
+import net.minecraft.client.main.Main;
+
+public class Start {
+    public static void main(String[] args) throws IOException {
+        /*
+         * start minecraft game application
+         * --version is just used as 'launched version' in snoop data and is required
+         * Working directory is used as gameDir if not provided
+         */
+        int INDEX = 30;
+        String assets = findAssets(INDEX);
+
+        Main.main(concat(new String[]{"--version", "mcp", "--accessToken", "0", "--assetsDir", assets, "--assetIndex", Integer.toString(INDEX), "--userProperties", "{}"}, args));
+    }
+
+    public static <T> T[] concat(T[] first, T[] second) {
+        T[] result = Arrays.copyOf(first, first.length + second.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+
+    private static String findAssets(int index) throws IOException {
+        // If we're explicitly told, use it
+        String ret = System.getenv("assetDirectory");
+        if (ret != null)
+            return ret;
+
+        // Minecraft is always a good option.
+        File dir = new File(getMCDir(), "assets");
+        if (hasIndex(dir, index))
+            return dir.getCanonicalPath();
+
+        // MCPConfig repo
+        dir = new File(".").getCanonicalFile();
+        while (dir != null && !"versions".equals(dir.getName()))
+            dir = dir.getParentFile();
+
+        if (dir != null) {
+            dir = new File(dir, "../build/assets");
+            if (hasIndex(dir, index))
+                return dir.getCanonicalPath();
+        }
+
+        // Random guess
+        return "assets";
+    }
+
+    private static boolean hasIndex(File root, int idx) {
+        return new File(root, "indexes/" + idx + ".json").exists();
+    }
+
+    private static File getMCDir() {
+        switch (OS.getCurrent()) {
+            case OSX:
+                return new File(System.getProperty("user.home") + "/Library/Application Support/minecraft");
+            case WINDOWS:
+                return new File(System.getenv("APPDATA") + "\\.minecraft");
+            case LINUX:
+            default:
+                return new File(System.getProperty("user.home") + "/.minecraft");
+        }
+    }
+
+    private enum OS {
+        WINDOWS("win"),
+        LINUX("linux", "unix"),
+        OSX("osx", "mac"),
+        UNKNOWN;
+
+        private final String[] keys;
+
+        OS(String... keys) {
+            this.keys = keys;
+        }
+
+        static OS getCurrent() {
+            String prop = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+            for (OS os : OS.values()) {
+                for (String key : os.keys) {
+                    if (prop.contains(key))
+                        return os;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+}

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/Minecraft.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/Minecraft.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/Minecraft.java
++++ b/net/minecraft/client/Minecraft.java
+@@ -2518,7 +2518,7 @@
+     }
+ 
+     public CompletableFuture<Void> delayTextureReload() {
+-        return this.<CompletableFuture<Void>>submit(this::reloadResourcePacks).thenCompose(result -> (CompletionStage<Void>)result);
++        return this.<CompletableFuture<Void>>submit((java.util.function.Supplier<CompletableFuture<Void>>)this::reloadResourcePacks).thenCompose(result -> (CompletionStage<Void>)result);
+     }
+ 
+     public void updateReportEnvironment(final ReportEnvironment environment) {

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/OptionInstance.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/OptionInstance.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/OptionInstance.java
++++ b/net/minecraft/client/OptionInstance.java
+@@ -237,7 +237,7 @@
+             final int width,
+             final OptionInstance.ValueUpdateListener<? super T> onValueChanged
+         ) {
+-            return instance -> CycleButton.builder(instance.toString, instance::get)
++            return instance -> CycleButton.builder(instance.toString, (Supplier<T>)instance::get)
+                 .withValues(this.valueListSupplier())
+                 .withTooltip(tooltip)
+                 .create(x, y, width, 20, instance.caption, (var4x, value) -> {

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/components/ChatComponent.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/components/ChatComponent.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/components/ChatComponent.java
++++ b/net/minecraft/client/gui/components/ChatComponent.java
+@@ -455,7 +455,7 @@
+     }
+ 
+     public void openScreen(final ChatComponent.ChatMethod chatMethod, final ChatScreen.ChatConstructor<?> chat) {
+-        this.minecraft.gui.setScreen(this.createScreen(chatMethod, (ChatScreen.ChatConstructor<Screen>)chat));
++        this.minecraft.gui.setScreen(this.createScreen(chatMethod, (ChatScreen.ChatConstructor<ChatScreen>)chat));
+     }
+ 
+     public void preserveCurrentChatScreen() {

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/font/FontSet.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/font/FontSet.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/font/FontSet.java
++++ b/net/minecraft/client/gui/font/FontSet.java
+@@ -100,7 +100,7 @@
+         }
+ 
+         Set<GlyphProvider> usedProviders = Sets.newHashSet();
+-        supportedGlyphs.forEach(codepoint -> {
++        supportedGlyphs.forEach((int codepoint) -> {
+             for (GlyphProvider provider : selectedProviders) {
+                 UnbakedGlyph glyph = provider.getGlyph(codepoint);
+                 if (glyph != null) {

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java
++++ b/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java
+@@ -284,7 +284,7 @@
+             public Entry(final Holder<FlatLevelGeneratorPreset> preset) {
+                 this.preset = preset.value();
+                 this.name = preset.unwrapKey()
+-                    .map(key -> Component.translatable(key.identifier().toLanguageKey("flat_world_preset")))
++                    .map(key -> (Component)Component.translatable(key.identifier().toLanguageKey("flat_world_preset")))
+                     .orElse(PresetFlatWorldScreen.UNKNOWN_PRESET);
+             }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/inventory/BookViewScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/inventory/BookViewScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/inventory/BookViewScreen.java
++++ b/net/minecraft/client/gui/screens/inventory/BookViewScreen.java
+@@ -271,7 +271,7 @@
+             }
+ 
+             WritableBookContent writableContent = itemStack.get(DataComponents.WRITABLE_BOOK_CONTENT);
+-            return writableContent != null ? new BookViewScreen.BookAccess(writableContent.getPages(filterEnabled).map(Component::literal).toList()) : null;
++            return writableContent != null ? new BookViewScreen.BookAccess(writableContent.getPages(filterEnabled).<Component>map(Component::literal).toList()) : null;
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java
++++ b/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java
+@@ -223,7 +223,7 @@
+                     try {
+                         Util.copyBetweenDirs(pack.getParent(), targetDir, path);
+                     } catch (IOException e) {
+-                        LOGGER.warn("Failed to copy datapack file  from {} to {}", path, targetDir, ex);
++                        LOGGER.warn("Failed to copy datapack file  from {} to {}", path, targetDir, e);
+                         showErrorToast.setTrue();
+                     }
+                 });

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java
++++ b/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java
+@@ -540,7 +540,7 @@
+                     try {
+                         Files.delete(path);
+                     } catch (IOException e) {
+-                        LOGGER.warn("Failed to remove temporary file {}", path, ex);
++                        LOGGER.warn("Failed to remove temporary file {}", path, e);
+                     }
+                 });
+             } catch (IOException e) {
+@@ -596,7 +596,7 @@
+                         targetDir = Files.createTempDirectory("mcworld-");
+                     } catch (IOException e) {
+                         LOGGER.warn("Failed to create temporary dir");
+-                        throw new UncheckedIOException(ex);
++                        throw new UncheckedIOException(e);
+                     }
+ 
+                     tempDataPackDir.setValue(targetDir);

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java
++++ b/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java
+@@ -315,7 +315,7 @@
+         public Component describePreset() {
+             return Optional.ofNullable(this.preset)
+                 .flatMap(Holder::unwrapKey)
+-                .map(key -> Component.translatable(key.identifier().toLanguageKey("generator")))
++                .map(key -> (Component)Component.translatable(key.identifier().toLanguageKey("generator")))
+                 .orElse(CUSTOM_WORLD_DESCRIPTION);
+         }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/LevelEventHandler.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/LevelEventHandler.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/client/renderer/LevelEventHandler.java
++++ b/net/minecraft/client/renderer/LevelEventHandler.java
+@@ -312,7 +312,7 @@
+                 this.level.addDestroyBlockEffect(pos, blockState);
+                 break;
+             case 2002:
+-            case 2007:
++            case 2007: {
+                 Vec3 particlePos = Vec3.atBottomCenterOf(pos);
+                 ItemParticleOption breakParticle = new ItemParticleOption(ParticleTypes.ITEM, Items.SPLASH_POTION);
+ 
+@@ -352,7 +352,8 @@
+ 
+                 this.level.playLocalSound(pos, SoundEvents.SPLASH_POTION_BREAK, SoundSource.NEUTRAL, 1.0F, random.nextFloat() * 0.1F + 0.9F, false);
+                 break;
+-            case 2003:
++            }
++            case 2003: {
+                 double x = pos.getX() + 0.5;
+                 double y = pos.getY();
+                 double z = pos.getZ() + 0.5;
+@@ -385,6 +386,7 @@
+                         );
+                 }
+                 break;
++            }
+             case 2004:
+                 for (int i = 0; i < 20; i++) {
+                     double x = pos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0;

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/block/dispatch/VariantSelector.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/block/dispatch/VariantSelector.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/block/dispatch/VariantSelector.java
++++ b/net/minecraft/client/renderer/block/dispatch/VariantSelector.java
+@@ -26,7 +26,7 @@
+                 Property<?> property = stateDefinition.getProperty(propertyName);
+                 if (property != null && iterator.hasNext()) {
+                     String propertyValue = iterator.next();
+-                    Comparable<?> value = getValueHelper((Property<Comparable<?>>)property, propertyValue);
++                    Comparable<?> value = getValueHelper(property, propertyValue);
+                     if (value == null) {
+                         throw new RuntimeException(
+                             "Unknown value: '" + propertyValue + "' for blockstate property: '" + propertyName + "' " + property.getPossibleValues()

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/blockentity/BeaconRenderer.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/blockentity/BeaconRenderer.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/client/renderer/blockentity/BeaconRenderer.java
++++ b/net/minecraft/client/renderer/blockentity/BeaconRenderer.java
+@@ -120,22 +120,12 @@
+             (pose, buffer) -> renderPart(pose, buffer, color, beamStart, beamEnd, 0.0F, wnz, enx, 0.0F, wsx, 0.0F, 0.0F, esz, 0.0F, 1.0F, vv1, vv2)
+         );
+         poseStack.popPose();
+-        wnx = -beamGlowRadius;
+-        wnz = -beamGlowRadius;
+-        enx = beamGlowRadius;
+-        enz = -beamGlowRadius;
+-        wsx = -beamGlowRadius;
+-        wsz = beamGlowRadius;
+-        esx = beamGlowRadius;
+-        esz = beamGlowRadius;
+-        uu1 = 0.0F;
+-        uu2 = 1.0F;
+-        vv2 = -1.0F + texVOff;
+-        vv1 = height * scale + vv2;
++        float vv2_f = -1.0F + texVOff;
++        float vv1_f = height * scale + vv2_f;
+         submitNodeCollector.submitCustomGeometry(
+             poseStack,
+             RenderTypes.beaconBeam(beamLocation, true),
+-            (pose, buffer) -> renderPart(pose, buffer, ARGB.color(32, color), beamStart, beamEnd, wnx, wnz, enx, enz, wsx, wsz, esx, esz, 0.0F, 1.0F, vv1, vv2)
++            (pose, buffer) -> renderPart(pose, buffer, ARGB.color(32, color), beamStart, beamEnd, -beamGlowRadius, -beamGlowRadius, beamGlowRadius, -beamGlowRadius, -beamGlowRadius, beamGlowRadius, beamGlowRadius, beamGlowRadius, 0.0F, 1.0F, vv1_f, vv2_f)
+         );
+         poseStack.popPose();
+     }

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java
++++ b/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java
+@@ -89,11 +89,11 @@
+     }
+ 
+     public <T extends Entity> EntityRenderer<? super T, ?> getRenderer(final T entity) {
+-        return switch (entity) {
+-            case AbstractClientPlayer player -> this.getAvatarRenderer((Map<PlayerModelType, AvatarRenderer<T>>)this.playerRenderers, (T)player);
+-            case ClientMannequin mannequin -> this.getAvatarRenderer((Map<PlayerModelType, AvatarRenderer<T>>)this.mannequinRenderers, (T)mannequin);
++        return (EntityRenderer<? super T, ?>)(switch (entity) {
++            case AbstractClientPlayer player -> this.getAvatarRenderer(this.playerRenderers, player);
++            case ClientMannequin mannequin -> this.getAvatarRenderer(this.mannequinRenderers, mannequin);
+             default -> (EntityRenderer)this.renderers.get(entity.getType());
+-        };
++        });
+     }
+ 
+     public AvatarRenderer<AbstractClientPlayer> getPlayerRenderer(final AbstractClientPlayer player) {

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java
++++ b/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java
+@@ -62,7 +62,7 @@
+ 
+         @Override
+         public FeatureRendererType<ModelFeatureRenderer.Submit<S>> featureType() {
+-            return (FeatureRendererType<ModelFeatureRenderer.Submit<S>>)ModelFeatureRenderer.TYPE;
++            return (FeatureRendererType<ModelFeatureRenderer.Submit<S>>)(FeatureRendererType)ModelFeatureRenderer.TYPE;
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/item/ConditionalItemModel.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/renderer/item/ConditionalItemModel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/item/ConditionalItemModel.java
++++ b/net/minecraft/client/renderer/item/ConditionalItemModel.java
+@@ -87,7 +87,7 @@
+         private static <T extends ConditionalItemModelProperty> T swapContext(
+             final T originalProperty, final RegistryContextSwapper contextSwapper, final ClientLevel context
+         ) {
+-            return (T)contextSwapper.swapTo(originalProperty.type().codec(), originalProperty, context.registryAccess()).result().orElse(originalProperty);
++            return (T)contextSwapper.swapTo(((MapCodec<T>)originalProperty.type()).codec(), originalProperty, context.registryAccess()).result().orElse(originalProperty);
+         }
+ 
+         @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/client/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/resources/model/ModelBakery.java
++++ b/net/minecraft/client/resources/model/ModelBakery.java
+@@ -247,7 +247,7 @@
+ 
+         @Override
+         public <T> T compute(final ModelBaker.SharedOperationKey<T> key) {
+-            return (T)this.operationCache.computeIfAbsent(key, this.cacheComputeFunction);
++            return (T)this.operationCache.computeIfAbsent((ModelBaker.SharedOperationKey)key, this.cacheComputeFunction);
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/Minecraft.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/Minecraft.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/Minecraft.java
++++ b/net/minecraft/client/Minecraft.java
+@@ -2521,7 +2521,7 @@
+     }
+ 
+     public CompletableFuture<Void> delayTextureReload() {
+-        return this.<CompletableFuture<Void>>submit(this::reloadResourcePacks).thenCompose(result -> (CompletionStage<Void>)result);
++        return this.<CompletableFuture<Void>>submit((java.util.function.Supplier<CompletableFuture<Void>>)this::reloadResourcePacks).thenCompose(result -> (CompletionStage<Void>)result);
+     }
+ 
+     public void updateReportEnvironment(final ReportEnvironment environment) {

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/OptionInstance.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/OptionInstance.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/OptionInstance.java
++++ b/net/minecraft/client/OptionInstance.java
+@@ -244,7 +244,7 @@
+             final int width,
+             final OptionInstance.ValueUpdateListener<? super T> onValueChanged
+         ) {
+-            return instance -> CycleButton.builder(instance.toString, instance::get)
++            return instance -> CycleButton.builder(instance.toString, (Supplier<T>)instance::get)
+                 .withValues(this.valueListSupplier())
+                 .withTooltip(tooltip)
+                 .create(x, y, width, 20, instance.caption, (var4x, value) -> {

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/components/ChatComponent.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/components/ChatComponent.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/components/ChatComponent.java
++++ b/net/minecraft/client/gui/components/ChatComponent.java
+@@ -458,7 +458,7 @@
+     }
+ 
+     public void openScreen(final ChatComponent.ChatMethod chatMethod, final ChatScreen.ChatConstructor<?> chat) {
+-        this.minecraft.gui.setScreen(this.createScreen(chatMethod, (ChatScreen.ChatConstructor<Screen>)chat));
++        this.minecraft.gui.setScreen(this.createScreen(chatMethod, (ChatScreen.ChatConstructor<ChatScreen>)chat));
+     }
+ 
+     public void preserveCurrentChatScreen() {

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/font/FontSet.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/font/FontSet.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/font/FontSet.java
++++ b/net/minecraft/client/gui/font/FontSet.java
+@@ -103,7 +103,7 @@
+         }
+ 
+         Set<GlyphProvider> usedProviders = Sets.newHashSet();
+-        supportedGlyphs.forEach(codepoint -> {
++        supportedGlyphs.forEach((int codepoint) -> {
+             for (GlyphProvider provider : selectedProviders) {
+                 UnbakedGlyph glyph = provider.getGlyph(codepoint);
+                 if (glyph != null) {

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java
++++ b/net/minecraft/client/gui/screens/PresetFlatWorldScreen.java
+@@ -289,7 +289,7 @@
+             public Entry(final Holder<FlatLevelGeneratorPreset> preset) {
+                 this.preset = preset.value();
+                 this.name = preset.unwrapKey()
+-                    .map(key -> Component.translatable(key.identifier().toLanguageKey("flat_world_preset")))
++                    .map(key -> (Component)Component.translatable(key.identifier().toLanguageKey("flat_world_preset")))
+                     .orElse(PresetFlatWorldScreen.UNKNOWN_PRESET);
+             }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/inventory/BookViewScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/inventory/BookViewScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/inventory/BookViewScreen.java
++++ b/net/minecraft/client/gui/screens/inventory/BookViewScreen.java
+@@ -275,7 +275,7 @@
+             }
+ 
+             WritableBookContent writableContent = itemStack.get(DataComponents.WRITABLE_BOOK_CONTENT);
+-            return writableContent != null ? new BookViewScreen.BookAccess(writableContent.getPages(filterEnabled).map(Component::literal).toList()) : null;
++            return writableContent != null ? new BookViewScreen.BookAccess(writableContent.getPages(filterEnabled).<Component>map(Component::literal).toList()) : null;
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java
++++ b/net/minecraft/client/gui/screens/packs/PackSelectionScreen.java
+@@ -226,7 +226,7 @@
+                     try {
+                         Util.copyBetweenDirs(pack.getParent(), targetDir, path);
+                     } catch (IOException e) {
+-                        LOGGER.warn("Failed to copy datapack file  from {} to {}", path, targetDir, ex);
++                        LOGGER.warn("Failed to copy datapack file  from {} to {}", path, targetDir, e);
+                         showErrorToast.setTrue();
+                     }
+                 });

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java
++++ b/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java
+@@ -543,7 +543,7 @@
+                     try {
+                         Files.delete(path);
+                     } catch (IOException e) {
+-                        LOGGER.warn("Failed to remove temporary file {}", path, ex);
++                        LOGGER.warn("Failed to remove temporary file {}", path, e);
+                     }
+                 });
+             } catch (IOException e) {
+@@ -599,7 +599,7 @@
+                         targetDir = Files.createTempDirectory("mcworld-");
+                     } catch (IOException e) {
+                         LOGGER.warn("Failed to create temporary dir");
+-                        throw new UncheckedIOException(ex);
++                        throw new UncheckedIOException(e);
+                     }
+ 
+                     tempDataPackDir.setValue(targetDir);

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java
++++ b/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java
+@@ -320,7 +320,7 @@
+         public Component describePreset() {
+             return Optional.ofNullable(this.preset)
+                 .flatMap(Holder::unwrapKey)
+-                .map(key -> Component.translatable(key.identifier().toLanguageKey("generator")))
++                .map(key -> (Component)Component.translatable(key.identifier().toLanguageKey("generator")))
+                 .orElse(CUSTOM_WORLD_DESCRIPTION);
+         }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/LevelEventHandler.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/LevelEventHandler.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/client/renderer/LevelEventHandler.java
++++ b/net/minecraft/client/renderer/LevelEventHandler.java
+@@ -315,7 +315,7 @@
+                 this.level.addDestroyBlockEffect(pos, blockState);
+                 break;
+             case 2002:
+-            case 2007:
++            case 2007: {
+                 Vec3 particlePos = Vec3.atBottomCenterOf(pos);
+                 ItemParticleOption breakParticle = new ItemParticleOption(ParticleTypes.ITEM, Items.SPLASH_POTION);
+ 
+@@ -355,7 +355,8 @@
+ 
+                 this.level.playLocalSound(pos, SoundEvents.SPLASH_POTION_BREAK, SoundSource.NEUTRAL, 1.0F, random.nextFloat() * 0.1F + 0.9F, false);
+                 break;
+-            case 2003:
++            }
++            case 2003: {
+                 double x = pos.getX() + 0.5;
+                 double y = pos.getY();
+                 double z = pos.getZ() + 0.5;
+@@ -388,6 +389,7 @@
+                         );
+                 }
+                 break;
++            }
+             case 2004:
+                 for (int i = 0; i < 20; i++) {
+                     double x = pos.getX() + 0.5 + (random.nextDouble() - 0.5) * 2.0;

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/block/dispatch/VariantSelector.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/block/dispatch/VariantSelector.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/block/dispatch/VariantSelector.java
++++ b/net/minecraft/client/renderer/block/dispatch/VariantSelector.java
+@@ -29,7 +29,7 @@
+                 Property<?> property = stateDefinition.getProperty(propertyName);
+                 if (property != null && iterator.hasNext()) {
+                     String propertyValue = iterator.next();
+-                    Comparable<?> value = getValueHelper((Property<Comparable<?>>)property, propertyValue);
++                    Comparable<?> value = getValueHelper(property, propertyValue);
+                     if (value == null) {
+                         throw new RuntimeException(
+                             "Unknown value: '" + propertyValue + "' for blockstate property: '" + propertyName + "' " + property.getPossibleValues()

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/blockentity/BeaconRenderer.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/blockentity/BeaconRenderer.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/client/renderer/blockentity/BeaconRenderer.java
++++ b/net/minecraft/client/renderer/blockentity/BeaconRenderer.java
+@@ -123,22 +123,12 @@
+             (pose, buffer) -> renderPart(pose, buffer, color, beamStart, beamEnd, 0.0F, wnz, enx, 0.0F, wsx, 0.0F, 0.0F, esz, 0.0F, 1.0F, vv1, vv2)
+         );
+         poseStack.popPose();
+-        wnx = -beamGlowRadius;
+-        wnz = -beamGlowRadius;
+-        enx = beamGlowRadius;
+-        enz = -beamGlowRadius;
+-        wsx = -beamGlowRadius;
+-        wsz = beamGlowRadius;
+-        esx = beamGlowRadius;
+-        esz = beamGlowRadius;
+-        uu1 = 0.0F;
+-        uu2 = 1.0F;
+-        vv2 = -1.0F + texVOff;
+-        vv1 = height * scale + vv2;
++        float vv2_f = -1.0F + texVOff;
++        float vv1_f = height * scale + vv2_f;
+         submitNodeCollector.submitCustomGeometry(
+             poseStack,
+             RenderTypes.beaconBeam(beamLocation, true),
+-            (pose, buffer) -> renderPart(pose, buffer, ARGB.color(32, color), beamStart, beamEnd, wnx, wnz, enx, enz, wsx, wsz, esx, esz, 0.0F, 1.0F, vv1, vv2)
++            (pose, buffer) -> renderPart(pose, buffer, ARGB.color(32, color), beamStart, beamEnd, -beamGlowRadius, -beamGlowRadius, beamGlowRadius, -beamGlowRadius, -beamGlowRadius, beamGlowRadius, beamGlowRadius, beamGlowRadius, 0.0F, 1.0F, vv1_f, vv2_f)
+         );
+         poseStack.popPose();
+     }

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java
++++ b/net/minecraft/client/renderer/entity/EntityRenderDispatcher.java
+@@ -92,11 +92,11 @@
+     }
+ 
+     public <T extends Entity> EntityRenderer<? super T, ?> getRenderer(final T entity) {
+-        return switch (entity) {
+-            case AbstractClientPlayer player -> this.getAvatarRenderer((Map<PlayerModelType, AvatarRenderer<T>>)this.playerRenderers, (T)player);
+-            case ClientMannequin mannequin -> this.getAvatarRenderer((Map<PlayerModelType, AvatarRenderer<T>>)this.mannequinRenderers, (T)mannequin);
++        return (EntityRenderer<? super T, ?>)(switch (entity) {
++            case AbstractClientPlayer player -> this.getAvatarRenderer(this.playerRenderers, player);
++            case ClientMannequin mannequin -> this.getAvatarRenderer(this.mannequinRenderers, mannequin);
+             default -> (EntityRenderer)this.renderers.get(entity.getType());
+-        };
++        });
+     }
+ 
+     public AvatarRenderer<AbstractClientPlayer> getPlayerRenderer(final AbstractClientPlayer player) {

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java
++++ b/net/minecraft/client/renderer/feature/ModelFeatureRenderer.java
+@@ -67,7 +67,7 @@
+ 
+         @Override
+         public FeatureRendererType<ModelFeatureRenderer.Submit<S>> featureType() {
+-            return (FeatureRendererType<ModelFeatureRenderer.Submit<S>>)ModelFeatureRenderer.TYPE;
++            return (FeatureRendererType<ModelFeatureRenderer.Submit<S>>)(FeatureRendererType)ModelFeatureRenderer.TYPE;
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/item/ConditionalItemModel.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/renderer/item/ConditionalItemModel.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/item/ConditionalItemModel.java
++++ b/net/minecraft/client/renderer/item/ConditionalItemModel.java
+@@ -91,7 +91,7 @@
+         private static <T extends ConditionalItemModelProperty> T swapContext(
+             final T originalProperty, final RegistryContextSwapper contextSwapper, final ClientLevel context
+         ) {
+-            return (T)contextSwapper.swapTo(originalProperty.type().codec(), originalProperty, context.registryAccess()).result().orElse(originalProperty);
++            return (T)contextSwapper.swapTo(((MapCodec<T>)originalProperty.type()).codec(), originalProperty, context.registryAccess()).result().orElse(originalProperty);
+         }
+ 
+         @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/joined/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/resources/model/ModelBakery.java
++++ b/net/minecraft/client/resources/model/ModelBakery.java
+@@ -254,7 +254,7 @@
+ 
+         @Override
+         public <T> T compute(final ModelBaker.SharedOperationKey<T> key) {
+-            return (T)this.operationCache.computeIfAbsent(key, this.cacheComputeFunction);
++            return (T)this.operationCache.computeIfAbsent((ModelBaker.SharedOperationKey)key, this.cacheComputeFunction);
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/advancements/predicates/MinMaxBounds.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/advancements/predicates/MinMaxBounds.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/advancements/predicates/MinMaxBounds.java
++++ b/net/minecraft/advancements/predicates/MinMaxBounds.java
+@@ -76,7 +76,7 @@
+         }
+ 
+         public static <T extends Number & Comparable<T>> MinMaxBounds.Bounds<T> any() {
+-            return new MinMaxBounds.Bounds<>(Optional.empty(), Optional.empty());
++            return new MinMaxBounds.Bounds<T>(Optional.empty(), Optional.empty());
+         }
+ 
+         public static <T extends Number & Comparable<T>> MinMaxBounds.Bounds<T> exactly(final T value) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/advancements/predicates/entity/EntityFlagsPredicate.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/advancements/predicates/entity/EntityFlagsPredicate.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/advancements/predicates/entity/EntityFlagsPredicate.java
++++ b/net/minecraft/advancements/predicates/entity/EntityFlagsPredicate.java
+@@ -70,7 +70,7 @@
+         } else {
+             return this.isFallFlying.isPresent() && entity instanceof LivingEntity living && living.isFallFlying() != this.isFallFlying.get()
+                 ? false
+-                : !(this.isBaby.isPresent() && entity instanceof LivingEntity living) || living.isBaby() == this.isBaby.get();
++                : !(this.isBaby.isPresent() && entity instanceof LivingEntity living2) || living2.isBaby() == this.isBaby.get();
+         }
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/advancements/predicates/entity/PlayerPredicate.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/advancements/predicates/entity/PlayerPredicate.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/advancements/predicates/entity/PlayerPredicate.java
++++ b/net/minecraft/advancements/predicates/entity/PlayerPredicate.java
+@@ -256,11 +256,11 @@
+         private static <T> MapCodec<PlayerPredicate.StatMatcher<T>> createTypedCodec(final StatType<T> type) {
+             return RecordCodecBuilder.mapCodec(
+                 i -> i.group(
+-                        (App<Mu<? extends PlayerPredicate.StatMatcher<?>>, Holder<T>>)type.getRegistry()
++                        type.getRegistry()
+                             .holderByNameCodec()
+                             .fieldOf("stat")
+                             .forGetter(PlayerPredicate.StatMatcher::value),
+-                        (App<Mu<? extends PlayerPredicate.StatMatcher<?>>, MinMaxBounds.Ints>)MinMaxBounds.Ints.CODEC
++                        MinMaxBounds.Ints.CODEC
+                             .optionalFieldOf("value", MinMaxBounds.Ints.ANY)
+                             .forGetter(PlayerPredicate.StatMatcher::range)
+                     )

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/arguments/ArgumentSignatures.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/arguments/ArgumentSignatures.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/commands/arguments/ArgumentSignatures.java
++++ b/net/minecraft/commands/arguments/ArgumentSignatures.java
+@@ -14,7 +14,7 @@
+     private static final int MAX_ARGUMENT_NAME_LENGTH = 16;
+ 
+     public ArgumentSignatures(final FriendlyByteBuf input) {
+-        this(input.readCollection(FriendlyByteBuf.limitValue(ArrayList::new, 8), ArgumentSignatures.Entry::new));
++        this(input.<Entry, List<Entry>>readCollection(FriendlyByteBuf.limitValue(ArrayList::new, 8), ArgumentSignatures.Entry::new));
+     }
+ 
+     public void write(final FriendlyByteBuf output) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/execution/tasks/BuildContexts.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/execution/tasks/BuildContexts.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/commands/execution/tasks/BuildContexts.java
++++ b/net/minecraft/commands/execution/tasks/BuildContexts.java
+@@ -56,7 +56,7 @@
+                     }
+ 
+                     RedirectModifier<T> modifier = contextToRun.getRedirectModifier();
+-                    if (modifier instanceof CustomModifierExecutor<T> customModifierExecutor) {
++                    if (modifier instanceof CustomModifierExecutor customModifierExecutor) {
+                         customModifierExecutor.apply(originalSource, currentSources, currentStage, modifiers, ExecutionControl.create(context, frame));
+                         return;
+                     }
+@@ -95,11 +95,11 @@
+ 
+         if (currentSources.isEmpty()) {
+             if (modifiers.isReturn()) {
+-                context.queueNext(new CommandQueueEntry<>(frame, FallthroughTask.instance()));
++                context.queueNext(new CommandQueueEntry<T>(frame, FallthroughTask.instance()));
+             }
+         } else {
+             CommandContext<T> executeContext = currentStage.getTopContext();
+-            if (executeContext.getCommand() instanceof CustomCommandExecutor<T> customCommandExecutor) {
++            if (executeContext.getCommand() instanceof CustomCommandExecutor customCommandExecutor) {
+                 ExecutionControl<T> executionControl = ExecutionControl.create(context, frame);
+ 
+                 for (T executionSource : currentSources) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/synchronization/ArgumentTypeInfos.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/synchronization/ArgumentTypeInfos.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/commands/synchronization/ArgumentTypeInfos.java
++++ b/net/minecraft/commands/synchronization/ArgumentTypeInfos.java
+@@ -119,11 +119,11 @@
+         register(registry, "dimension", DimensionArgument.class, SingletonArgumentInfo.contextFree(DimensionArgument::dimension));
+         register(registry, "gamemode", GameModeArgument.class, SingletonArgumentInfo.contextFree(GameModeArgument::gameMode));
+         register(registry, "time", TimeArgument.class, new TimeArgument.Info());
+-        register(registry, "resource_or_tag", fixClassType(ResourceOrTagArgument.class), new ResourceOrTagArgument.Info());
+-        register(registry, "resource_or_tag_key", fixClassType(ResourceOrTagKeyArgument.class), new ResourceOrTagKeyArgument.Info());
+-        register(registry, "resource", fixClassType(ResourceArgument.class), new ResourceArgument.Info());
+-        register(registry, "resource_key", fixClassType(ResourceKeyArgument.class), new ResourceKeyArgument.Info());
+-        register(registry, "resource_selector", fixClassType(ResourceSelectorArgument.class), new ResourceSelectorArgument.Info());
++        register(registry, "resource_or_tag", (Class)fixClassType(ResourceOrTagArgument.class), new ResourceOrTagArgument.Info());
++        register(registry, "resource_or_tag_key", (Class)fixClassType(ResourceOrTagKeyArgument.class), new ResourceOrTagKeyArgument.Info());
++        register(registry, "resource", (Class)fixClassType(ResourceArgument.class), new ResourceArgument.Info());
++        register(registry, "resource_key", (Class)fixClassType(ResourceKeyArgument.class), new ResourceKeyArgument.Info());
++        register(registry, "resource_selector", (Class)fixClassType(ResourceSelectorArgument.class), new ResourceSelectorArgument.Info());
+         register(registry, "template_mirror", TemplateMirrorArgument.class, SingletonArgumentInfo.contextFree(TemplateMirrorArgument::templateMirror));
+         register(registry, "template_rotation", TemplateRotationArgument.class, SingletonArgumentInfo.contextFree(TemplateRotationArgument::templateRotation));
+         register(registry, "heightmap", HeightmapTypeArgument.class, SingletonArgumentInfo.contextFree(HeightmapTypeArgument::heightmap));

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/synchronization/SuggestionProviders.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/commands/synchronization/SuggestionProviders.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/commands/synchronization/SuggestionProviders.java
++++ b/net/minecraft/commands/synchronization/SuggestionProviders.java
+@@ -37,7 +37,7 @@
+         if (previous != null) {
+             throw new IllegalArgumentException("A command suggestion provider is already registered with the name '" + name + "'");
+         } else {
+-            return new SuggestionProviders.RegisteredSuggestion(name, provider);
++            return (SuggestionProvider<S>)new SuggestionProviders.RegisteredSuggestion(name, provider);
+         }
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/Registry.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/Registry.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/core/Registry.java
++++ b/net/minecraft/core/Registry.java
+@@ -136,7 +136,7 @@
+     Holder<T> wrapAsHolder(T value);
+ 
+     default Iterable<Holder<T>> getTagOrEmpty(final TagKey<T> id) {
+-        return DataFixUtils.orElse(this.get(id), List.<T>of());
++        return DataFixUtils.orElse((Optional<Iterable>)(Optional)this.get(id), List.<T>of());
+     }
+ 
+     Stream<HolderSet.Named<T>> getTags();

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/RegistrySetBuilder.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/RegistrySetBuilder.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/core/RegistrySetBuilder.java
++++ b/net/minecraft/core/RegistrySetBuilder.java
+@@ -421,13 +421,13 @@
+         }
+ 
+         private <T> Holder.Reference<T> getOrCreate(final ResourceKey<T> id) {
+-            return (Holder.Reference<T>)this.holders.computeIfAbsent(id, k -> Holder.Reference.createStandAlone(this.owner, (ResourceKey<Object>)k));
++            return (Holder.Reference<T>)((Map)this.holders).computeIfAbsent(id, k -> Holder.Reference.createStandAlone(this.owner, (ResourceKey<Object>)k));
+         }
+     }
+ 
+     private static class UniversalOwner implements HolderOwner<Object> {
+         public <T> HolderOwner<T> cast() {
+-            return this;
++            return (HolderOwner<T>)this;
+         }
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/DataComponentPatch.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/DataComponentPatch.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/core/component/DataComponentPatch.java
++++ b/net/minecraft/core/component/DataComponentPatch.java
+@@ -53,7 +53,7 @@
+                 }
+             }
+ 
+-            return map;
++            return (Reference2ObjectMap)map;
+         });
+     public static final StreamCodec<RegistryFriendlyByteBuf, DataComponentPatch> STREAM_CODEC = createStreamCodec(new DataComponentPatch.CodecGetter() {
+         @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/DataComponentType.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/DataComponentType.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/core/component/DataComponentType.java
++++ b/net/minecraft/core/component/DataComponentType.java
+@@ -110,7 +110,7 @@
+ 
+             @Override
+             public String toString() {
+-                return Util.getRegisteredName((Registry<DataComponentType.Builder.SimpleType<T>>)BuiltInRegistries.DATA_COMPONENT_TYPE, this);
++                return Util.getRegisteredName((Registry)BuiltInRegistries.DATA_COMPONENT_TYPE, this);
+             }
+         }
+     }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/TypedDataComponent.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/TypedDataComponent.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/core/component/TypedDataComponent.java
++++ b/net/minecraft/core/component/TypedDataComponent.java
+@@ -11,7 +11,7 @@
+     public static final StreamCodec<RegistryFriendlyByteBuf, TypedDataComponent<?>> STREAM_CODEC = new StreamCodec<RegistryFriendlyByteBuf, TypedDataComponent<?>>() {
+         public TypedDataComponent<?> decode(final RegistryFriendlyByteBuf input) {
+             DataComponentType<?> type = DataComponentType.STREAM_CODEC.decode(input);
+-            return decodeTyped(input, (DataComponentType<T>)type);
++            return decodeTyped(input, (DataComponentType)type);
+         }
+ 
+         private static <T> TypedDataComponent<T> decodeTyped(final RegistryFriendlyByteBuf input, final DataComponentType<T> type) {
+@@ -19,7 +19,7 @@
+         }
+ 
+         public void encode(final RegistryFriendlyByteBuf output, final TypedDataComponent<?> value) {
+-            encodeCap(output, (TypedDataComponent<T>)value);
++            encodeCap(output, (TypedDataComponent)value);
+         }
+ 
+         private static <T> void encodeCap(final RegistryFriendlyByteBuf output, final TypedDataComponent<T> component) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/predicates/DataComponentPredicate.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/component/predicates/DataComponentPredicate.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/core/component/predicates/DataComponentPredicate.java
++++ b/net/minecraft/core/component/predicates/DataComponentPredicate.java
+@@ -26,7 +26,7 @@
+         )
+         .map(
+             singles -> singles.stream().collect(Collectors.toMap(DataComponentPredicate.Single::type, DataComponentPredicate.Single::predicate)),
+-            map -> map.entrySet().stream().map(DataComponentPredicate.Single::fromEntry).toList()
++            map -> map.entrySet().stream().<DataComponentPredicate.Single<?>>map(DataComponentPredicate.Single::fromEntry).toList()
+         );
+ 
+     static MapCodec<DataComponentPredicate.Single<?>> singleCodec(final String name) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/registries/BuiltInRegistries.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/core/registries/BuiltInRegistries.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/core/registries/BuiltInRegistries.java
++++ b/net/minecraft/core/registries/BuiltInRegistries.java
+@@ -394,7 +394,7 @@
+         Bootstrap.checkBootstrapCalled(() -> "registry " + name.identifier());
+         Identifier key = name.identifier();
+         LOADERS.put(key, () -> loader.run(registry));
+-        WRITABLE_REGISTRY.register((ResourceKey<WritableRegistry<?>>)name, registry, RegistrationInfo.BUILT_IN);
++        WRITABLE_REGISTRY.register((ResourceKey)name, registry, RegistrationInfo.BUILT_IN);
+         return registry;
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/info/RegistryDumpReport.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/info/RegistryDumpReport.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/info/RegistryDumpReport.java
++++ b/net/minecraft/data/info/RegistryDumpReport.java
+@@ -34,7 +34,7 @@
+             result.addProperty("default", defaultKey.toString());
+         }
+ 
+-        int registryId = BuiltInRegistries.REGISTRY.getId(registry);
++        int registryId = ((Registry)BuiltInRegistries.REGISTRY).getId(registry);
+         result.addProperty("protocol_id", registryId);
+         JsonObject entries = new JsonObject();
+         registry.listElements().forEach(holder -> {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/loot/LootTableProvider.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/loot/LootTableProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/loot/LootTableProvider.java
++++ b/net/minecraft/data/loot/LootTableProvider.java
+@@ -84,7 +84,7 @@
+             problems.forEach((id, problem) -> LOGGER.warn("Found validation problem in {}: {}", id, problem.description()));
+             throw new IllegalStateException("Failed to validate loot tables, see logs");
+         } else {
+-            return CompletableFuture.allOf(tables.entrySet().stream().map(entry -> {
++            return CompletableFuture.allOf(tables.entrySet().stream().<CompletableFuture<?>>map(entry -> {
+                 ResourceKey<LootTable> id = entry.getKey();
+                 LootTable table = entry.getValue();
+                 Path path = this.pathProvider.json(id.identifier());

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/registries/RegistriesDatapackGenerator.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/registries/RegistriesDatapackGenerator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/registries/RegistriesDatapackGenerator.java
++++ b/net/minecraft/data/registries/RegistriesDatapackGenerator.java
+@@ -50,7 +50,7 @@
+                     PackOutput.PathProvider pathProvider = this.output.createRegistryElementsPathProvider(registryKey);
+                     return CompletableFuture.allOf(
+                         registry.listElements()
+-                            .map(e -> dumpValue(pathProvider.json(e.key().identifier()), cache, writeOps, v.elementCodec(), e.value()))
++                            .<CompletableFuture<?>>map(e -> dumpValue(pathProvider.json(e.key().identifier()), cache, writeOps, v.elementCodec(), e.value()))
+                             .toArray(CompletableFuture[]::new)
+                     );
+                 }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/data/tags/TagsProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/data/tags/TagsProvider.java
++++ b/net/minecraft/data/tags/TagsProvider.java
+@@ -77,7 +77,7 @@
+                         this.builders
+                             .entrySet()
+                             .stream()
+-                            .map(
++                            .<CompletableFuture<?>>map(
+                                 entry -> {
+                                     Identifier id = entry.getKey();
+                                     TagBuilder builder = entry.getValue();

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/locale/Language.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/locale/Language.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/locale/Language.java
++++ b/net/minecraft/locale/Language.java
+@@ -57,7 +57,7 @@
+ 
+             @Override
+             public FormattedCharSequence getVisualOrder(final FormattedText logicalOrderText) {
+-                return outputx -> logicalOrderText.visit(
++                return output -> logicalOrderText.visit(
+                         (style, contents) -> StringDecomposer.iterateFormatted(contents, style, output) ? Optional.empty() : FormattedText.STOP_ITERATION,
+                         Style.EMPTY
+                     )

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/chat/LastSeenMessages.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/chat/LastSeenMessages.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/chat/LastSeenMessages.java
++++ b/net/minecraft/network/chat/LastSeenMessages.java
+@@ -42,7 +42,7 @@
+         public static final LastSeenMessages.Packed EMPTY = new LastSeenMessages.Packed(List.of());
+ 
+         public Packed(final FriendlyByteBuf input) {
+-            this(input.readCollection(FriendlyByteBuf.limitValue(ArrayList::new, 20), MessageSignature.Packed::read));
++            this(input.<MessageSignature.Packed, List<MessageSignature.Packed>>readCollection(FriendlyByteBuf.limitValue(ArrayList::new, 20), MessageSignature.Packed::read));
+         }
+ 
+         public void write(final FriendlyByteBuf output) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/codec/StreamCodec.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/codec/StreamCodec.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/codec/StreamCodec.java
++++ b/net/minecraft/network/codec/StreamCodec.java
+@@ -620,7 +620,7 @@
+     }
+ 
+     default <S extends B> StreamCodec<S, V> cast() {
+-        return this;
++        return (StreamCodec<S, V>)this;
+     }
+ 
+     @FunctionalInterface

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/ProtocolInfoBuilder.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/ProtocolInfoBuilder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/protocol/ProtocolInfoBuilder.java
++++ b/net/minecraft/network/protocol/ProtocolInfoBuilder.java
+@@ -41,7 +41,7 @@
+         final PacketType<P> bundlerPacket, final Function<Iterable<Packet<? super T>>, P> constructor, final D delimiterPacket
+     ) {
+         StreamCodec<ByteBuf, D> delimitedCodec = StreamCodec.unit(delimiterPacket);
+-        PacketType<D> delimiterType = (PacketType<D>)delimiterPacket.type();
++        PacketType<D> delimiterType = (PacketType)delimiterPacket.type();
+         this.codecs.add(new ProtocolInfoBuilder.CodecEntry<>(delimiterType, delimitedCodec, null));
+         this.bundlerInfo = BundlerInfo.createForPacket(bundlerPacket, constructor, delimiterPacket);
+         return this;

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java
++++ b/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java
+@@ -34,7 +34,7 @@
+ 
+             private <T extends CustomPacketPayload> void writeCap(final B output, final CustomPacketPayload.Type<T> type, final CustomPacketPayload payload) {
+                 output.writeIdentifier(type.id());
+-                StreamCodec<B, T> codec = this.findCodec(type.id);
++                StreamCodec<B, T> codec = (StreamCodec)this.findCodec(type.id);
+                 codec.encode(output, (T)payload);
+             }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/configuration/ClientboundUpdateEnabledFeaturesPacket.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/configuration/ClientboundUpdateEnabledFeaturesPacket.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/protocol/configuration/ClientboundUpdateEnabledFeaturesPacket.java
++++ b/net/minecraft/network/protocol/configuration/ClientboundUpdateEnabledFeaturesPacket.java
+@@ -14,7 +14,7 @@
+     );
+ 
+     private ClientboundUpdateEnabledFeaturesPacket(final FriendlyByteBuf input) {
+-        this(input.readCollection(HashSet::new, FriendlyByteBuf::readIdentifier));
++        this(input.<Identifier, Set<Identifier>>readCollection(HashSet::new, FriendlyByteBuf::readIdentifier));
+     }
+ 
+     private void write(final FriendlyByteBuf output) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/game/ClientboundGameRuleValuesPacket.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/protocol/game/ClientboundGameRuleValuesPacket.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/protocol/game/ClientboundGameRuleValuesPacket.java
++++ b/net/minecraft/network/protocol/game/ClientboundGameRuleValuesPacket.java
+@@ -12,7 +12,7 @@
+ import net.minecraft.world.level.gamerules.GameRule;
+ 
+ public record ClientboundGameRuleValuesPacket(Map<ResourceKey<GameRule<?>>, String> values) implements Packet<ClientGamePacketListener> {
+-    public static final StreamCodec<FriendlyByteBuf, ClientboundGameRuleValuesPacket> STREAM_CODEC = ByteBufCodecs.map(
++    public static final StreamCodec<FriendlyByteBuf, ClientboundGameRuleValuesPacket> STREAM_CODEC = ByteBufCodecs.<FriendlyByteBuf, ResourceKey<GameRule<?>>, String, Map<ResourceKey<GameRule<?>>, String>>map(
+             HashMap::new, ResourceKey.streamCodec(Registries.GAME_RULE), ByteBufCodecs.STRING_UTF8
+         )
+         .map(ClientboundGameRuleValuesPacket::new, ClientboundGameRuleValuesPacket::values);

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/syncher/EntityDataSerializer.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/syncher/EntityDataSerializer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/syncher/EntityDataSerializer.java
++++ b/net/minecraft/network/syncher/EntityDataSerializer.java
+@@ -13,7 +13,7 @@
+     T copy(T value);
+ 
+     static <T> EntityDataSerializer<T> forValueType(final StreamCodec<? super RegistryFriendlyByteBuf, T> codec) {
+-        return () -> codec;
++        return (ForValueType<T>)() -> codec;
+     }
+ 
+     interface ForValueType<T> extends EntityDataSerializer<T> {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/syncher/EntityDataSerializers.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/network/syncher/EntityDataSerializers.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/syncher/EntityDataSerializers.java
++++ b/net/minecraft/network/syncher/EntityDataSerializers.java
+@@ -97,7 +97,7 @@
+     );
+     public static final EntityDataSerializer<Direction> DIRECTION = EntityDataSerializer.forValueType(Direction.STREAM_CODEC);
+     public static final EntityDataSerializer<Optional<EntityReference<LivingEntity>>> OPTIONAL_LIVING_ENTITY_REFERENCE = EntityDataSerializer.forValueType(
+-        EntityReference.streamCodec().apply(ByteBufCodecs::optional)
++        EntityReference.<LivingEntity>streamCodec().apply(ByteBufCodecs::optional)
+     );
+     public static final EntityDataSerializer<Optional<GlobalPos>> OPTIONAL_GLOBAL_POS = EntityDataSerializer.forValueType(
+         GlobalPos.STREAM_CODEC.apply(ByteBufCodecs::optional)

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/resources/HolderSetCodec.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/resources/HolderSetCodec.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/resources/HolderSetCodec.java
++++ b/net/minecraft/resources/HolderSetCodec.java
+@@ -65,7 +65,7 @@
+     }
+ 
+     private static <E> DataResult<HolderSet<E>> lookupTag(final HolderGetter<E> registry, final TagKey<E> key) {
+-        return registry.get(key)
++        return (DataResult)registry.get(key)
+             .map(DataResult::success)
+             .orElseGet(() -> DataResult.error(() -> "Missing tag: '" + key.location() + "' in '" + key.registry().identifier() + "'"));
+     }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/resources/RegistryDataLoader.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/resources/RegistryDataLoader.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/resources/RegistryDataLoader.java
++++ b/net/minecraft/resources/RegistryDataLoader.java
+@@ -80,7 +80,7 @@
+ 
+ public class RegistryDataLoader {
+     private static final Logger LOGGER = LogUtils.getLogger();
+-    private static final Comparator<ResourceKey<?>> ERROR_KEY_COMPARATOR = Comparator.comparing(ResourceKey::registry).thenComparing(ResourceKey::identifier);
++    private static final Comparator<ResourceKey<?>> ERROR_KEY_COMPARATOR = Comparator.<ResourceKey<?>, Identifier>comparing(ResourceKey::registry).thenComparing(ResourceKey::identifier);
+     public static final List<RegistryDataLoader.RegistryData<?>> WORLDGEN_REGISTRIES = List.of(
+         new RegistryDataLoader.RegistryData<>(Registries.DIMENSION_TYPE, DimensionType.DIRECT_CODEC),
+         new RegistryDataLoader.RegistryData<>(Registries.BIOME, Biome.DIRECT_CODEC),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/dedicated/Settings.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/dedicated/Settings.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/dedicated/Settings.java
++++ b/net/minecraft/server/dedicated/Settings.java
+@@ -113,7 +113,7 @@
+         String value = this.getStringRaw(key);
+         V result = MoreObjects.firstNonNull(value != null ? deserializer.apply(value) : null, defaultValue);
+         this.properties.put(key, serializer.apply(result));
+-        return new Settings.MutableValue<>(key, result, serializer);
++        return new MutableValue<>(key, result, serializer);
+     }
+ 
+     protected <V> V get(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/dialog/action/StaticAction.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/dialog/action/StaticAction.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/dialog/action/StaticAction.java
++++ b/net/minecraft/server/dialog/action/StaticAction.java
+@@ -14,7 +14,7 @@
+ 
+         for (ClickEvent.Action action : ClickEvent.Action.class.getEnumConstants()) {
+             if (action.isAllowedFromServer()) {
+-                MapCodec<ClickEvent> mapCodec = action.valueCodec();
++                MapCodec<ClickEvent> mapCodec = (MapCodec<ClickEvent>)action.valueCodec();
+                 result.put(action, mapCodec.xmap(StaticAction::new, StaticAction::value));
+             }
+         }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/IncomingRpcMethods.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/IncomingRpcMethods.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/jsonrpc/IncomingRpcMethods.java
++++ b/net/minecraft/server/jsonrpc/IncomingRpcMethods.java
+@@ -355,7 +355,7 @@
+             .description("Get the available game rule keys and their current values")
+             .response("gamerules", Schema.TYPED_GAME_RULE_SCHEMA.asRef().asArray())
+             .register(methodRegistry, "gamerules");
+-        IncomingRpcMethod.method(GameRulesService::update)
++        IncomingRpcMethod.<GameRulesService.GameRuleUpdate<?>, GameRulesService.GameRuleUpdate<?>>method(GameRulesService::update)
+             .description("Update game rule value")
+             .param("gamerule", Schema.UNTYPED_GAME_RULE_SCHEMA.asRef())
+             .response("gamerule", Schema.TYPED_GAME_RULE_SCHEMA.asRef())

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/api/MethodInfo.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/api/MethodInfo.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/server/jsonrpc/api/MethodInfo.java
++++ b/net/minecraft/server/jsonrpc/api/MethodInfo.java
+@@ -26,7 +26,7 @@
+     }
+ 
+     private static <Params, Result> MapCodec<MethodInfo<Params, Result>> typedCodec() {
+-        return RecordCodecBuilder.mapCodec(
++        return (MapCodec)RecordCodecBuilder.<MethodInfo>mapCodec(
+             i -> i.group(
+                     Codec.STRING.fieldOf("description").forGetter(MethodInfo::description),
+                     paramsTypedCodec().fieldOf("params").forGetter(MethodInfo::params),
+@@ -41,7 +41,7 @@
+     }
+ 
+     public record Named<Params, Result>(Identifier name, MethodInfo<Params, Result> contents) {
+-        public static final Codec<MethodInfo.Named<?, ?>> CODEC = typedCodec();
++        public static final Codec<MethodInfo.Named<?, ?>> CODEC = (Codec)typedCodec();
+ 
+         public static <Params, Result> Codec<MethodInfo.Named<Params, Result>> typedCodec() {
+             return RecordCodecBuilder.create(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/api/Schema.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/api/Schema.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/server/jsonrpc/api/Schema.java
++++ b/net/minecraft/server/jsonrpc/api/Schema.java
+@@ -36,19 +36,19 @@
+ public record Schema<T>(
+     Optional<URI> reference, List<String> type, Optional<Schema<?>> items, Map<String, Schema<?>> properties, List<String> enumValues, Codec<T> codec
+ ) {
+-    public static final Codec<? extends Schema<?>> CODEC = Codec.recursive(
++    public static final Codec<? extends Schema<?>> CODEC = (Codec)Codec.<Schema>recursive(
+             "Schema",
+             subCodec -> RecordCodecBuilder.create(
+                 i -> i.group(
+-                        (App<Mu<? extends Schema<?>>, Optional<URI>>)ReferenceUtil.REFERENCE_CODEC.optionalFieldOf("$ref").forGetter(Schema::reference),
+-                        (App<Mu<? extends Schema<?>>, List<String>>)ExtraCodecs.compactListCodec(Codec.STRING)
++                        ReferenceUtil.REFERENCE_CODEC.optionalFieldOf("$ref").forGetter(Schema::reference),
++                        ExtraCodecs.compactListCodec(Codec.STRING)
+                             .optionalFieldOf("type", List.of())
+                             .forGetter(Schema::type),
+-                        (App<Mu<? extends Schema<?>>, Optional<? extends Schema<?>>>)subCodec.optionalFieldOf("items").forGetter(Schema::items),
+-                        (App<Mu<? extends Schema<?>>, Map<String, ? extends Schema<?>>>)Codec.unboundedMap(Codec.STRING, subCodec)
++                        subCodec.optionalFieldOf("items").forGetter(Schema::items),
++                        Codec.unboundedMap(Codec.STRING, subCodec)
+                             .optionalFieldOf("properties", Map.of())
+                             .forGetter(Schema::properties),
+-                        (App<Mu<? extends Schema<?>>, List<String>>)Codec.STRING.listOf().optionalFieldOf("enum", List.of()).forGetter(Schema::enumValues)
++                        Codec.STRING.listOf().optionalFieldOf("enum", List.of()).forGetter(Schema::enumValues)
+                     )
+                     .apply(i, (ref, type, items, properties, enumValues) -> null)
+             )

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/methods/DiscoveryService.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/methods/DiscoveryService.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/jsonrpc/methods/DiscoveryService.java
++++ b/net/minecraft/server/jsonrpc/methods/DiscoveryService.java
+@@ -40,7 +40,7 @@
+ 
+         private static MapCodec<DiscoveryService.DiscoverComponents> typedSchema() {
+             return RecordCodecBuilder.mapCodec(
+-                i -> i.group(Codec.unboundedMap(Codec.STRING, Schema.CODEC).fieldOf("schemas").forGetter(DiscoveryService.DiscoverComponents::schemas))
++                i -> i.group(Codec.unboundedMap(Codec.STRING, (Codec<Schema<?>>)Schema.CODEC).fieldOf("schemas").forGetter(DiscoveryService.DiscoverComponents::schemas))
+                     .apply(i, DiscoveryService.DiscoverComponents::new)
+             );
+         }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/methods/GameRulesService.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/jsonrpc/methods/GameRulesService.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/server/jsonrpc/methods/GameRulesService.java
++++ b/net/minecraft/server/jsonrpc/methods/GameRulesService.java
+@@ -52,10 +52,10 @@
+         private static <T> MapCodec<? extends GameRulesService.GameRuleUpdate<T>> getValueAndTypeCodec(final GameRule<T> gameRule) {
+             return RecordCodecBuilder.mapCodec(
+                 i -> i.group(
+-                        (App<Mu<? extends GameRulesService.GameRuleUpdate<?>>, GameRuleType>)StringRepresentable.fromEnum(GameRuleType::values)
++                        StringRepresentable.fromEnum(GameRuleType::values)
+                             .fieldOf("type")
+                             .forGetter(r -> r.gameRule.gameRuleType()),
+-                        (App<Mu<? extends GameRulesService.GameRuleUpdate<?>>, T>)gameRule.valueCodec()
++                        gameRule.valueCodec()
+                             .fieldOf("value")
+                             .forGetter(GameRulesService.GameRuleUpdate::value)
+                     )

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/level/ChunkTaskPriorityQueue.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/level/ChunkTaskPriorityQueue.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/level/ChunkTaskPriorityQueue.java
++++ b/net/minecraft/server/level/ChunkTaskPriorityQueue.java
+@@ -10,7 +10,7 @@
+ public class ChunkTaskPriorityQueue {
+     public static final int PRIORITY_LEVEL_COUNT = ChunkLevel.MAX_LEVEL + 2;
+     private final List<Long2ObjectLinkedOpenHashMap<List<Runnable>>> queuesPerPriority = IntStream.range(0, PRIORITY_LEVEL_COUNT)
+-        .mapToObj(priority -> new Long2ObjectLinkedOpenHashMap<>())
++        .mapToObj(priority -> new Long2ObjectLinkedOpenHashMap<List<Runnable>>())
+         .toList();
+     private volatile int topPriorityQueueIndex = PRIORITY_LEVEL_COUNT;
+     private final String name;

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1012,7 +1012,7 @@
+         if (carried.has(DataComponents.WRITABLE_BOOK_CONTENT)) {
+             ItemStack writtenBook = carried.transmuteCopy(Items.WRITTEN_BOOK);
+             writtenBook.remove(DataComponents.WRITABLE_BOOK_CONTENT);
+-            List<Filterable<Component>> pages = contents.stream().map(page -> this.filterableFromOutgoing(page).map(Component::literal)).toList();
++            List<Filterable<Component>> pages = contents.stream().map(page -> this.filterableFromOutgoing(page).<Component>map(Component::literal)).toList();
+             writtenBook.set(
+                 DataComponents.WRITTEN_BOOK_CONTENT, new WrittenBookContent(this.filterableFromOutgoing(title), this.player.getPlainTextName(), 0, pages, true)
+             );

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/packs/metadata/MetadataSectionType.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/server/packs/metadata/MetadataSectionType.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/packs/metadata/MetadataSectionType.java
++++ b/net/minecraft/server/packs/metadata/MetadataSectionType.java
+@@ -10,7 +10,7 @@
+ 
+     public record WithValue<T>(MetadataSectionType<T> type, T value) {
+         public <U> Optional<U> unwrapToType(final MetadataSectionType<U> type) {
+-            return type == this.type ? Optional.of(this.value) : Optional.empty();
++            return type == this.type ? Optional.of((U)this.value) : Optional.empty();
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/AbstractListBuilder.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/AbstractListBuilder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/AbstractListBuilder.java
++++ b/net/minecraft/util/AbstractListBuilder.java
+@@ -27,7 +27,7 @@
+ 
+     @Override
+     public ListBuilder<T> add(final T value) {
+-        this.builder = this.builder.map(b -> (T)this.append((B)b, value));
++        this.builder = this.builder.map(b -> this.append((B)b, value));
+         return this;
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/CubicSpline.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/CubicSpline.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/CubicSpline.java
++++ b/net/minecraft/util/CubicSpline.java
+@@ -63,7 +63,7 @@
+             "CubicSpline",
+             subSplineCodec -> Codec.either(Codec.FLOAT, CubicSpline.Multipoint.codec(coordinateCodec, subSplineCodec))
+                 .xmap(
+-                    e -> e.map(CubicSpline.Constant::new, (Function<? super CubicSpline.Multipoint<I>, ? extends CubicSpline.Constant<I>>)(m -> m)),
++                    e -> e.map(CubicSpline.Constant::new, m -> m),
+                     spline -> {
+                         return switch (spline) {
+                             case CubicSpline.Constant(float value) -> Either.left(value);

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/EncoderCache.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/EncoderCache.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/EncoderCache.java
++++ b/net/minecraft/util/EncoderCache.java
+@@ -33,7 +33,7 @@
+ 
+             @Override
+             public <T> DataResult<T> encode(final A input, final DynamicOps<T> ops, final T prefix) {
+-                return EncoderCache.this.cache
++                return (DataResult<T>)EncoderCache.this.cache
+                     .getUnchecked(new EncoderCache.Key<>(codec, input, ops))
+                     .map(value -> value instanceof Tag tag ? tag.copy() : value);
+             }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/ExtraCodecs.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/ExtraCodecs.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/util/ExtraCodecs.java
++++ b/net/minecraft/util/ExtraCodecs.java
+@@ -283,7 +283,7 @@
+             P max = l.get(1);
+             return makeInterval.apply(min, max);
+         }), p -> ImmutableList.of(getMin.apply((I)p), getMax.apply((I)p)));
+-        Codec<I> objectCodec = RecordCodecBuilder.<Pair>create(
++        Codec<I> objectCodec = RecordCodecBuilder.<Pair<P, P>>create(
+                 i -> i.group(pointCodec.fieldOf(lowerBoundName).forGetter(Pair::getFirst), pointCodec.fieldOf(upperBoundName).forGetter(Pair::getSecond))
+                     .apply(i, Pair::of)
+             )
+@@ -608,7 +608,7 @@
+             public <T> RecordBuilder<T> encode(final V input, final DynamicOps<T> ops, final RecordBuilder<T> builder) {
+                 K type = (K)typeGetter.apply(input);
+                 builder.add(typeKey, typeCodec.encodeStart(ops, type));
+-                DataResult<T> parameters = this.encode(valueCodec.apply(type), input, ops);
++                DataResult<T> parameters = this.encode((Codec)valueCodec.apply(type), input, ops);
+                 if (parameters.result().isEmpty() || !Objects.equals(parameters.result().get(), ops.emptyMap())) {
+                     builder.add(valueKey, parameters);
+                 }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/HashOps.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/HashOps.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/HashOps.java
++++ b/net/minecraft/util/HashOps.java
+@@ -53,7 +53,7 @@
+     private static final Comparator<HashCode> HASH_COMPARATOR = Comparator.comparingLong(HashCode::padToLong);
+     private static final Comparator<Entry<HashCode, HashCode>> MAP_ENTRY_ORDER = Entry.<HashCode, HashCode>comparingByKey(HASH_COMPARATOR)
+         .thenComparing(Entry.comparingByValue(HASH_COMPARATOR));
+-    private static final Comparator<Pair<HashCode, HashCode>> MAPLIKE_ENTRY_ORDER = Comparator.comparing(Pair::getFirst, HASH_COMPARATOR)
++    private static final Comparator<Pair<HashCode, HashCode>> MAPLIKE_ENTRY_ORDER = Comparator.<Pair<HashCode, HashCode>, HashCode>comparing(Pair::getFirst, HASH_COMPARATOR)
+         .thenComparing(Pair::getSecond, HASH_COMPARATOR);
+     public static final HashOps CRC32C_INSTANCE = new HashOps(Hashing.crc32c());
+     private final HashFunction hashFunction;

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/PlaceholderLookupProvider.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/PlaceholderLookupProvider.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/util/PlaceholderLookupProvider.java
++++ b/net/minecraft/util/PlaceholderLookupProvider.java
+@@ -100,11 +100,11 @@
+         }
+ 
+         public <T> HolderGetter<T> castAsLookup() {
+-            return this;
++            return (HolderGetter<T>)this;
+         }
+ 
+         public <T> HolderOwner<T> castAsOwner() {
+-            return this;
++            return (HolderOwner<T>)this;
+         }
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/SortedArraySet.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/SortedArraySet.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/SortedArraySet.java
++++ b/net/minecraft/util/SortedArraySet.java
+@@ -28,7 +28,7 @@
+     }
+ 
+     public static <T extends Comparable<T>> SortedArraySet<T> create(final int initialCapacity) {
+-        return new SortedArraySet<>(initialCapacity, Comparator.naturalOrder());
++        return new SortedArraySet<>(initialCapacity, Comparator.<T>naturalOrder());
+     }
+ 
+     public static <T> SortedArraySet<T> create(final Comparator<T> comparator) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/Util.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/Util.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/Util.java
++++ b/net/minecraft/util/Util.java
+@@ -624,7 +624,7 @@
+     public static <K extends Enum<K>, V> Map<K, V> makeEnumMap(final Class<K> keyType, final Function<K, V> function) {
+         EnumMap<K, V> map = new EnumMap<>(keyType);
+ 
+-        for (K key : (Enum[])keyType.getEnumConstants()) {
++        for (K key : keyType.getEnumConstants()) {
+             map.put(key, function.apply(key));
+         }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/DataFixers.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/DataFixers.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/util/datafix/DataFixers.java
++++ b/net/minecraft/util/datafix/DataFixers.java
+@@ -1172,7 +1172,7 @@
+         );
+         Schema v3086 = fixerUpper.addSchema(3086, SAME_NAMESPACED);
+         fixerUpper.addFixer(
+-            new EntityVariantFix(v3086, "Change cat variant type", References.ENTITY, "minecraft:cat", "CatType", Util.make(new Int2ObjectOpenHashMap(), m -> {
++            new EntityVariantFix(v3086, "Change cat variant type", References.ENTITY, "minecraft:cat", "CatType", Util.make(new Int2ObjectOpenHashMap<String>(), m -> {
+                 m.defaultReturnValue("minecraft:tabby");
+                 m.put(0, "minecraft:tabby");
+                 m.put(1, "minecraft:black");
+@@ -1208,7 +1208,7 @@
+         Schema v3087 = fixerUpper.addSchema(3087, SAME_NAMESPACED);
+         fixerUpper.addFixer(
+             new EntityVariantFix(
+-                v3087, "Change frog variant type", References.ENTITY, "minecraft:frog", "Variant", Util.make(new Int2ObjectOpenHashMap(), m -> {
++                v3087, "Change frog variant type", References.ENTITY, "minecraft:frog", "Variant", Util.make(new Int2ObjectOpenHashMap<String>(), m -> {
+                     m.put(0, "minecraft:temperate");
+                     m.put(1, "minecraft:warm");
+                     m.put(2, "minecraft:cold");

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/BlockEntityUUIDFix.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/BlockEntityUUIDFix.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/datafix/fixes/BlockEntityUUIDFix.java
++++ b/net/minecraft/util/datafix/fixes/BlockEntityUUIDFix.java
+@@ -21,7 +21,7 @@
+         return tag.get("Owner")
+             .get()
+             .map(ownerTag -> replaceUUIDString((Dynamic<?>)ownerTag, "Id", "Id").orElse((Dynamic<?>)ownerTag))
+-            .map(ownerTag -> tag.remove("Owner").set("SkullOwner", (Dynamic<?>)ownerTag))
++            .<Dynamic<?>>map(ownerTag -> tag.remove("Owner").set("SkullOwner", (Dynamic<?>)ownerTag))
+             .result()
+             .orElse(tag);
+     }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/ChunkBedBlockEntityInjecterFix.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/ChunkBedBlockEntityInjecterFix.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/util/datafix/fixes/ChunkBedBlockEntityInjecterFix.java
++++ b/net/minecraft/util/datafix/fixes/ChunkBedBlockEntityInjecterFix.java
+@@ -40,8 +40,8 @@
+         return TypeRewriteRule.seq(
+             this.fixTypeEverywhere(
+                 "InjectBedBlockEntityType",
+-                this.getInputSchema().findChoiceType(References.BLOCK_ENTITY),
+-                this.getOutputSchema().findChoiceType(References.BLOCK_ENTITY),
++                (com.mojang.datafixers.types.templates.TaggedChoice.TaggedChoiceType<String>)this.getInputSchema().findChoiceType(References.BLOCK_ENTITY),
++                (com.mojang.datafixers.types.templates.TaggedChoice.TaggedChoiceType<String>)this.getOutputSchema().findChoiceType(References.BLOCK_ENTITY),
+                 ops -> v -> v
+             ),
+             this.fixTypeEverywhereTyped(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java
++++ b/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java
+@@ -182,7 +182,7 @@
+         int relativeZ = pos >>> 8 & 15;
+         String type = typeGetter.apply(container != null ? container.get().get(relativeX, relativeY, relativeZ) : null);
+         return tag.createMap(
+-            ImmutableMap.builder()
++            ImmutableMap.<Dynamic<?>, Dynamic<?>>builder()
+                 .put(tag.createString("i"), tag.createString(type))
+                 .put(tag.createString("x"), tag.createInt(sectionX * 16 + relativeX))
+                 .put(tag.createString("y"), tag.createInt(sectionY * 16 + relativeY))

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/EntitySpawnerItemVariantComponentFix.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/EntitySpawnerItemVariantComponentFix.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/util/datafix/fixes/EntitySpawnerItemVariantComponentFix.java
++++ b/net/minecraft/util/datafix/fixes/EntitySpawnerItemVariantComponentFix.java
+@@ -32,9 +32,9 @@
+                 String id = input.getOptional(idFinder).map(Pair::getSecond).orElse("");
+ 
+                 return switch (id) {
+-                    case "minecraft:salmon_bucket" -> input.updateTyped(componentsFinder, EntitySpawnerItemVariantComponentFix::fixSalmonBucket);
+-                    case "minecraft:axolotl_bucket" -> input.updateTyped(componentsFinder, EntitySpawnerItemVariantComponentFix::fixAxolotlBucket);
+-                    case "minecraft:tropical_fish_bucket" -> input.updateTyped(componentsFinder, EntitySpawnerItemVariantComponentFix::fixTropicalFishBucket);
++                    case "minecraft:salmon_bucket" -> input.updateTyped(componentsFinder, (Fixer)EntitySpawnerItemVariantComponentFix::fixSalmonBucket);
++                    case "minecraft:axolotl_bucket" -> input.updateTyped(componentsFinder, (Fixer)EntitySpawnerItemVariantComponentFix::fixAxolotlBucket);
++                    case "minecraft:tropical_fish_bucket" -> input.updateTyped(componentsFinder, (Fixer)EntitySpawnerItemVariantComponentFix::fixTropicalFishBucket);
+                     case "minecraft:painting" -> input.updateTyped(
+                         componentsFinder,
+                         components -> Util.writeAndReadTypedOrThrow(components, components.getType(), EntitySpawnerItemVariantComponentFix::fixPainting)

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/LeavesFix.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/LeavesFix.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/datafix/fixes/LeavesFix.java
++++ b/net/minecraft/util/datafix/fixes/LeavesFix.java
+@@ -345,7 +345,7 @@
+             return this.isSkippable()
+                 ? section
+                 : section.update(DSL.remainderFinder(), tag -> tag.set("BlockStates", tag.createLongList(Arrays.stream(this.storage.getRaw()))))
+-                    .set(this.paletteFinder, this.palette.stream().map(b -> Pair.of(References.BLOCK_STATE.typeName(), b)).collect(Collectors.toList()));
++                    .set(this.paletteFinder, this.palette.stream().<Pair<String, Dynamic<?>>>map(b -> Pair.of(References.BLOCK_STATE.typeName(), b)).collect(Collectors.toList()));
+         }
+ 
+         public boolean isSkippable() {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/OptionsKeyLwjgl3Fix.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/OptionsKeyLwjgl3Fix.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/datafix/fixes/OptionsKeyLwjgl3Fix.java
++++ b/net/minecraft/util/datafix/fixes/OptionsKeyLwjgl3Fix.java
+@@ -160,7 +160,7 @@
+                 } else {
+                     return Pair.of(entry.getKey(), entry.getValue());
+                 }
+-            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse(tag))
++            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse((com.mojang.serialization.Dynamic)tag))
+         );
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/OptionsKeyTranslationFix.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/datafix/fixes/OptionsKeyTranslationFix.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/util/datafix/fixes/OptionsKeyTranslationFix.java
++++ b/net/minecraft/util/datafix/fixes/OptionsKeyTranslationFix.java
+@@ -26,7 +26,7 @@
+                 }
+ 
+                 return Pair.of(entry.getKey(), entry.getValue());
+-            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse(tag))
++            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse((com.mojang.serialization.Dynamic)tag))
+         );
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/filefix/FileFixerUpper.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/util/filefix/FileFixerUpper.java.patch
@@ -1,0 +1,30 @@
+--- a/net/minecraft/util/filefix/FileFixerUpper.java
++++ b/net/minecraft/util/filefix/FileFixerUpper.java
+@@ -344,13 +344,13 @@
+                 try {
+                     Files.move(worldFolder, oldWorldFolder, moveOptions);
+                 } catch (Exception e) {
+-                    LOGGER.warn("Failed to move outdated world folder out of the way; will try to delete instead: ", ex);
++                    LOGGER.warn("Failed to move outdated world folder out of the way; will try to delete instead: ", e);
+ 
+                     try {
+                         deleteDirectory(worldFolder);
+                     } catch (Exception e2) {
+-                        LOGGER.warn("Failed to delete outdated world folder: ", ex);
+-                        throw new FailedCleanupFileFixException(ex, tempWorldTopLevel.getFileName().toString(), fileSystemCapabilities);
++                        LOGGER.warn("Failed to delete outdated world folder: ", e2);
++                        throw new FailedCleanupFileFixException(e2, tempWorldTopLevel.getFileName().toString(), fileSystemCapabilities);
+                     }
+                 }
+ 
+@@ -359,8 +359,8 @@
+                 try {
+                     Files.move(tempWorldTopLevel, worldFolder, moveOptions);
+                 } catch (Exception e) {
+-                    LOGGER.warn("Failed to move in new world folder: ", exx);
+-                    throw new FailedCleanupFileFixException(exx, tempWorldTopLevel.getFileName().toString(), fileSystemCapabilities);
++                    LOGGER.warn("Failed to move in new world folder: ", e);
++                    throw new FailedCleanupFileFixException(e, tempWorldTopLevel.getFileName().toString(), fileSystemCapabilities);
+                 }
+ 
+                 succeeded.setTrue();

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/EnvironmentAttributeMap.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/EnvironmentAttributeMap.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/attribute/EnvironmentAttributeMap.java
++++ b/net/minecraft/world/attribute/EnvironmentAttributeMap.java
+@@ -18,7 +18,7 @@
+     public static final EnvironmentAttributeMap EMPTY = new EnvironmentAttributeMap(Map.of());
+     public static final Codec<EnvironmentAttributeMap> CODEC = Codec.lazyInitialized(
+         () -> Codec.dispatchedMap(EnvironmentAttributes.CODEC, Util.memoize(EnvironmentAttributeMap.Entry::createCodec))
+-            .xmap(EnvironmentAttributeMap::new, v -> v.entries)
++            .xmap((java.util.function.Function<Map, EnvironmentAttributeMap>)EnvironmentAttributeMap::new, v -> (Map)((EnvironmentAttributeMap)v).entries)
+     );
+     public static final Codec<EnvironmentAttributeMap> NETWORK_CODEC = CODEC.xmap(
+         EnvironmentAttributeMap::filterSyncable, EnvironmentAttributeMap::filterSyncable

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/AttributeModifier.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/AttributeModifier.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/attribute/modifier/AttributeModifier.java
++++ b/net/minecraft/world/attribute/modifier/AttributeModifier.java
+@@ -73,7 +73,7 @@
+     );
+ 
+     static <Value> AttributeModifier<Value, Value> override() {
+-        return AttributeModifier.OverrideModifier.INSTANCE;
++        return (AttributeModifier<Value, Value>)AttributeModifier.OverrideModifier.INSTANCE;
+     }
+ 
+     Subject apply(Subject subject, Argument argument);

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/ColorModifier.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/ColorModifier.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/attribute/modifier/ColorModifier.java
++++ b/net/minecraft/world/attribute/modifier/ColorModifier.java
+@@ -25,10 +25,10 @@
+             return LerpFunction.ofColor();
+         }
+     };
+-    ColorModifier<Integer> ADD = ARGB::addRgb;
+-    ColorModifier<Integer> SUBTRACT = ARGB::subtractRgb;
+-    ColorModifier<Integer> MULTIPLY_RGB = ARGB::multiply;
+-    ColorModifier<Integer> MULTIPLY_ARGB = ARGB::multiply;
++    ColorModifier<Integer> ADD = (RgbModifier)ARGB::addRgb;
++    ColorModifier<Integer> SUBTRACT = (RgbModifier)ARGB::subtractRgb;
++    ColorModifier<Integer> MULTIPLY_RGB = (RgbModifier)ARGB::multiply;
++    ColorModifier<Integer> MULTIPLY_ARGB = (ArgbModifier)ARGB::multiply;
+     ColorModifier<ColorModifier.BlendToGray> BLEND_TO_GRAY = new ColorModifier<ColorModifier.BlendToGray>() {
+         public Integer apply(final Integer subject, final ColorModifier.BlendToGray argument) {
+             int multipliedGreyscale = ARGB.scaleRGB(ARGB.greyscale(subject), argument.brightness);

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/FloatModifier.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/FloatModifier.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/attribute/modifier/FloatModifier.java
++++ b/net/minecraft/world/attribute/modifier/FloatModifier.java
+@@ -21,11 +21,11 @@
+             return (alpha, from, to) -> new FloatWithAlpha(Mth.lerp(alpha, from.value(), to.value()), Mth.lerp(alpha, from.alpha(), to.alpha()));
+         }
+     };
+-    FloatModifier<Float> ADD = Float::sum;
++    FloatModifier<Float> ADD = (FloatModifier.Simple)Float::sum;
+     FloatModifier<Float> SUBTRACT = (FloatModifier.Simple)(a, b) -> a - b;
+     FloatModifier<Float> MULTIPLY = (FloatModifier.Simple)(a, b) -> a * b;
+-    FloatModifier<Float> MINIMUM = Math::min;
+-    FloatModifier<Float> MAXIMUM = Math::max;
++    FloatModifier<Float> MINIMUM = (FloatModifier.Simple)Math::min;
++    FloatModifier<Float> MAXIMUM = (FloatModifier.Simple)Math::max;
+ 
+     @FunctionalInterface
+     interface Simple extends FloatModifier<Float> {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/IntegerModifier.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/attribute/modifier/IntegerModifier.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/world/attribute/modifier/IntegerModifier.java
++++ b/net/minecraft/world/attribute/modifier/IntegerModifier.java
+@@ -5,11 +5,11 @@
+ import net.minecraft.world.attribute.LerpFunction;
+ 
+ public interface IntegerModifier<Argument> extends AttributeModifier<Integer, Argument> {
+-    IntegerModifier<Integer> ADD = Integer::sum;
+-    IntegerModifier<Integer> SUBTRACT = (a, b) -> a - b;
+-    IntegerModifier<Integer> MULTIPLY = (a, b) -> a * b;
+-    IntegerModifier<Integer> MINIMUM = Math::min;
+-    IntegerModifier<Integer> MAXIMUM = Math::max;
++    IntegerModifier<Integer> ADD = (IntegerModifier.Simple)Integer::sum;
++    IntegerModifier<Integer> SUBTRACT = (IntegerModifier.Simple)(a, b) -> a - b;
++    IntegerModifier<Integer> MULTIPLY = (IntegerModifier.Simple)(a, b) -> a * b;
++    IntegerModifier<Integer> MINIMUM = (IntegerModifier.Simple)Math::min;
++    IntegerModifier<Integer> MAXIMUM = (IntegerModifier.Simple)Math::max;
+ 
+     Integer apply(Integer integer, Argument argument);
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/EntityReference.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/EntityReference.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/EntityReference.java
++++ b/net/minecraft/world/entity/EntityReference.java
+@@ -118,7 +118,7 @@
+     }
+ 
+     public static <StoredEntityType extends UniquelyIdentifyable> @Nullable EntityReference<StoredEntityType> read(final ValueInput input, final String key) {
+-        return input.read(key, codec()).orElse(null);
++        return input.read(key, EntityReference.<StoredEntityType>codec()).orElse(null);
+     }
+ 
+     public static <StoredEntityType extends UniquelyIdentifyable> @Nullable EntityReference<StoredEntityType> readWithOldOwnerConversion(
+@@ -129,7 +129,7 @@
+             ? of(uuid.get())
+             : input.getString(key)
+                 .map(oldName -> OldUsersConverter.convertMobOwnerIfNecessary(level.getServer(), oldName))
+-                .map(EntityReference::new)
++                .map(EntityReference<StoredEntityType>::new)
+                 .orElse(null);
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/SpawnPlacements.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/SpawnPlacements.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/SpawnPlacements.java
++++ b/net/minecraft/world/entity/SpawnPlacements.java
+@@ -84,7 +84,7 @@
+         }
+ 
+         SpawnPlacements.Data data = DATA_BY_TYPE.get(type);
+-        return data == null || data.predicate.test(type, level, spawnReason, pos, random);
++        return data == null || data.predicate.test((EntityType)type, level, spawnReason, pos, random);
+     }
+ 
+     static {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/ai/Brain.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/ai/Brain.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/Brain.java
++++ b/net/minecraft/world/entity/ai/Brain.java
+@@ -231,7 +231,7 @@
+     }
+ 
+     private static <U> void callVisitor(final Brain.Visitor visitor, final MemoryModuleType<U> memoryModuleType, final MemorySlot<?> slot) {
+-        slot.visit(memoryModuleType, visitor);
++        ((MemorySlot<U>)slot).visit(memoryModuleType, visitor);
+     }
+ 
+     public <U> boolean isMemoryValue(final MemoryModuleType<U> memoryType, final U value) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/ai/behavior/InteractWith.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/ai/behavior/InteractWith.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/behavior/InteractWith.java
++++ b/net/minecraft/world/entity/ai/behavior/InteractWith.java
+@@ -43,7 +43,7 @@
+                     if (selfFilter.test(body) && entities.contains(isTargetValid)) {
+                         Optional<LivingEntity> closest = entities.findClosest(mob -> mob.distanceToSqr(body) <= interactionRangeSqr && isTargetValid.test(mob));
+                         closest.ifPresent(mob -> {
+-                            target.set(mob);
++                            target.set((T)mob);
+                             lookTarget.set(new EntityTracker(mob, true));
+                             walkTarget.set(new WalkTarget(new EntityTracker(mob, false), speedModifier, stopDistance));
+                         });

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/allay/Allay.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/allay/Allay.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/allay/Allay.java
++++ b/net/minecraft/world/entity/animal/allay/Allay.java
+@@ -79,7 +79,7 @@
+     public static final int MAX_NOTEBLOCK_DISTANCE = 1024;
+     private static final EntityDataAccessor<Boolean> DATA_DANCING = SynchedEntityData.defineId(Allay.class, EntityDataSerializers.BOOLEAN);
+     private static final EntityDataAccessor<Boolean> DATA_CAN_DUPLICATE = SynchedEntityData.defineId(Allay.class, EntityDataSerializers.BOOLEAN);
+-    private static final Brain.Provider<Allay> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Allay> BRAIN_PROVIDER = Brain.<Allay>provider(
+         List.of(MemoryModuleType.LIKED_PLAYER, MemoryModuleType.LIKED_NOTEBLOCK_POSITION, MemoryModuleType.LIKED_NOTEBLOCK_COOLDOWN_TICKS),
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_PLAYERS, SensorType.HURT_BY, SensorType.NEAREST_ITEMS),
+         var0 -> AllayAi.getActivities()
+@@ -119,7 +119,7 @@
+ 
+     @Override
+     public Brain<Allay> getBrain() {
+-        return super.getBrain();
++        return (Brain<Allay>)super.getBrain();
+     }
+ 
+     public static AttributeSupplier.Builder createAttributes() {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/allay/AllayAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/allay/AllayAi.java.patch
@@ -1,0 +1,35 @@
+--- a/net/minecraft/world/entity/animal/allay/AllayAi.java
++++ b/net/minecraft/world/entity/animal/allay/AllayAi.java
+@@ -59,12 +59,12 @@
+     }
+ 
+     private static ActivityData<Allay> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Allay>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+                 new Swim<>(0.8F),
+-                new AnimalPanic(2.5F),
++                new AnimalPanic<>(2.5F),
+                 new LookAtTargetSink(45, 90),
+                 new MoveToTargetSink(),
+                 new CountDownCooldownTicks(MemoryModuleType.LIKED_NOTEBLOCK_COOLDOWN_TICKS),
+@@ -74,7 +74,7 @@
+     }
+ 
+     private static ActivityData<Allay> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Allay>create(
+             Activity.IDLE,
+             0,
+             ImmutableList.of(
+@@ -82,7 +82,7 @@
+                 new GoAndGiveItemsToTarget<>(AllayAi::getItemDepositPosition, 2.25F, 20, AllayAi::onItemThrown),
+                 StayCloseToTarget.create(AllayAi::getItemDepositPosition, Predicate.not(AllayAi::hasWantedItem), 4, 16, 2.25F),
+                 SetEntityLookTargetSometimes.create(6.0F, UniformInt.of(30, 60)),
+-                new RunOne(
++                new RunOne<Allay>(
+                     ImmutableList.of(
+                         Pair.of(RandomStroll.fly(1.0F), 2), Pair.of(SetWalkTargetFromLookTarget.create(1.0F, 3), 2), Pair.of(new DoNothing(30, 60), 1)
+                     )

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/allay/AllayAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/allay/AllayAi.java.patch
@@ -24,8 +24,7 @@
              Activity.IDLE,
              0,
              ImmutableList.of(
-@@ -82,7 +82,7 @@
-                 new GoAndGiveItemsToTarget<>(AllayAi::getItemDepositPosition, 2.25F, 20, AllayAi::onItemThrown),
+@@ -89,6 +89,6 @@
                  StayCloseToTarget.create(AllayAi::getItemDepositPosition, Predicate.not(AllayAi::hasWantedItem), 4, 16, 2.25F),
                  SetEntityLookTargetSometimes.create(6.0F, UniformInt.of(30, 60)),
 -                new RunOne(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/armadillo/Armadillo.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/armadillo/Armadillo.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/armadillo/Armadillo.java
++++ b/net/minecraft/world/entity/animal/armadillo/Armadillo.java
+@@ -61,7 +61,7 @@
+     private static final double SCARE_DISTANCE_HORIZONTAL = 7.0;
+     private static final double SCARE_DISTANCE_VERTICAL = 2.0;
+     private static final EntityDimensions BABY_DIMENSIONS = EntityTypes.ARMADILLO.getDimensions().scale(0.6F).withEyeHeight(0.21875F);
+-    private static final Brain.Provider<Armadillo> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Armadillo> BRAIN_PROVIDER = Brain.<Armadillo>provider(
+         List.of(
+             SensorType.NEAREST_LIVING_ENTITIES, SensorType.HURT_BY, SensorType.FOOD_TEMPTATIONS, SensorType.NEAREST_ADULT, SensorType.ARMADILLO_SCARE_DETECTED
+         ),
+@@ -134,7 +134,7 @@
+ 
+     @Override
+     public Brain<Armadillo> getBrain() {
+-        return super.getBrain();
++        return (Brain<Armadillo>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/armadillo/ArmadilloAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/armadillo/ArmadilloAi.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/armadillo/ArmadilloAi.java
++++ b/net/minecraft/world/entity/animal/armadillo/ArmadilloAi.java
+@@ -60,7 +60,7 @@
+     }
+ 
+     private static ActivityData<Armadillo> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Armadillo>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -81,7 +81,7 @@
+     }
+ 
+     private static ActivityData<Armadillo> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Armadillo>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/axolotl/Axolotl.java
++++ b/net/minecraft/world/entity/animal/axolotl/Axolotl.java
+@@ -76,7 +76,7 @@
+ public class Axolotl extends Animal implements Bucketable {
+     public static final int TOTAL_PLAYDEAD_TIME = 200;
+     private static final int POSE_ANIMATION_TICKS = 10;
+-    private static final Brain.Provider<Axolotl> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Axolotl> BRAIN_PROVIDER = Brain.<Axolotl>provider(
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_ADULT, SensorType.HURT_BY, SensorType.AXOLOTL_ATTACKABLES, SensorType.FOOD_TEMPTATIONS),
+         var0 -> AxolotlAi.getActivities()
+     );
+@@ -531,7 +531,7 @@
+ 
+     @Override
+     public Brain<Axolotl> getBrain() {
+-        return super.getBrain();
++        return (Brain<Axolotl>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java
++++ b/net/minecraft/world/entity/animal/axolotl/AxolotlAi.java
+@@ -52,7 +52,7 @@
+     }
+ 
+     protected static ActivityData<Axolotl> initPlayDeadActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Axolotl>create(
+             Activity.PLAY_DEAD,
+             ImmutableList.of(Pair.of(0, new PlayDead()), Pair.of(1, EraseMemoryIf.create(BehaviorUtils::isBreeding, MemoryModuleType.PLAY_DEAD_TICKS))),
+             ImmutableSet.of(Pair.of(MemoryModuleType.PLAY_DEAD_TICKS, MemoryStatus.VALUE_PRESENT)),
+@@ -61,7 +61,7 @@
+     }
+ 
+     protected static ActivityData<Axolotl> initFightActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Axolotl>create(
+             Activity.FIGHT,
+             0,
+             ImmutableList.of(
+@@ -75,7 +75,7 @@
+     }
+ 
+     protected static ActivityData<Axolotl> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Axolotl>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -88,7 +88,7 @@
+     }
+ 
+     protected static ActivityData<Axolotl> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Axolotl>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/camel/Camel.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/camel/Camel.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/camel/Camel.java
++++ b/net/minecraft/world/entity/animal/camel/Camel.java
+@@ -72,7 +72,7 @@
+     private static final int IDLE_MINIMAL_DURATION_TICKS = 80;
+     private static final float SITTING_HEIGHT_DIFFERENCE = 1.43F;
+     private static final long DEFAULT_LAST_POSE_CHANGE_TICK = 0L;
+-    private static final Brain.Provider<Camel> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Camel> BRAIN_PROVIDER = Brain.<Camel>provider(
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.HURT_BY, SensorType.FOOD_TEMPTATIONS, SensorType.NEAREST_ADULT), var0 -> CamelAi.getActivities()
+     );
+     public static final EntityDataAccessor<Boolean> DASH = SynchedEntityData.defineId(Camel.class, EntityDataSerializers.BOOLEAN);
+@@ -154,7 +154,7 @@
+ 
+     @Override
+     public Brain<Camel> getBrain() {
+-        return super.getBrain();
++        return (Brain<Camel>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/camel/CamelAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/camel/CamelAi.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/camel/CamelAi.java
++++ b/net/minecraft/world/entity/animal/camel/CamelAi.java
+@@ -46,7 +46,7 @@
+     }
+ 
+     private static ActivityData<Camel> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Camel>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -61,7 +61,7 @@
+     }
+ 
+     private static ActivityData<Camel> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Camel>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/Frog.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/Frog.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/frog/Frog.java
++++ b/net/minecraft/world/entity/animal/frog/Frog.java
+@@ -69,7 +69,7 @@
+ import org.jspecify.annotations.Nullable;
+ 
+ public class Frog extends Animal {
+-    private static final Brain.Provider<Frog> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Frog> BRAIN_PROVIDER = Brain.<Frog>provider(
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.HURT_BY, SensorType.FROG_ATTACKABLES, SensorType.FROG_TEMPTATIONS, SensorType.IS_IN_WATER),
+         var0 -> FrogAi.getActivities()
+     );
+@@ -99,7 +99,7 @@
+ 
+     @Override
+     public Brain<Frog> getBrain() {
+-        return super.getBrain();
++        return (Brain<Frog>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/FrogAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/FrogAi.java.patch
@@ -1,0 +1,56 @@
+--- a/net/minecraft/world/entity/animal/frog/FrogAi.java
++++ b/net/minecraft/world/entity/animal/frog/FrogAi.java
+@@ -69,7 +69,7 @@
+     }
+ 
+     private static ActivityData<Frog> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Frog>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -83,7 +83,7 @@
+     }
+ 
+     private static ActivityData<Frog> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Frog>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),
+@@ -113,7 +113,7 @@
+     }
+ 
+     private static ActivityData<Frog> initSwimActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Frog>create(
+             Activity.SWIM,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),
+@@ -145,7 +145,7 @@
+     }
+ 
+     private static ActivityData<Frog> initLaySpawnActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Frog>create(
+             Activity.LAY_SPAWN,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),
+@@ -173,7 +173,7 @@
+     }
+ 
+     private static ActivityData<Frog> initJumpActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Frog>create(
+             Activity.LONG_JUMP,
+             ImmutableList.of(
+                 Pair.of(0, new LongJumpMidJump(TIME_BETWEEN_LONG_JUMPS, SoundEvents.FROG_STEP)),
+@@ -201,7 +201,7 @@
+     }
+ 
+     private static ActivityData<Frog> initTongueActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Frog>create(
+             Activity.TONGUE,
+             0,
+             ImmutableList.of(StopAttackingIfTargetInvalid.create(), new ShootTongue(SoundEvents.FROG_TONGUE, SoundEvents.FROG_EAT)),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/Tadpole.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/Tadpole.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/frog/Tadpole.java
++++ b/net/minecraft/world/entity/animal/frog/Tadpole.java
+@@ -51,7 +51,7 @@
+     public static final float HITBOX_HEIGHT = 0.3F;
+     private int age = 0;
+     protected int ageLockParticleTimer = 0;
+-    private static final Brain.Provider<Tadpole> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Tadpole> BRAIN_PROVIDER = Brain.<Tadpole>provider(
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_PLAYERS, SensorType.HURT_BY, SensorType.FROG_TEMPTATIONS),
+         var0 -> TadpoleAi.getActivities()
+     );
+@@ -74,7 +74,7 @@
+ 
+     @Override
+     public Brain<Tadpole> getBrain() {
+-        return super.getBrain();
++        return (Brain<Tadpole>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/TadpoleAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/frog/TadpoleAi.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/frog/TadpoleAi.java
++++ b/net/minecraft/world/entity/animal/frog/TadpoleAi.java
+@@ -33,7 +33,7 @@
+     }
+ 
+     private static ActivityData<Tadpole> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Tadpole>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -46,7 +46,7 @@
+     }
+ 
+     private static ActivityData<Tadpole> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Tadpole>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/goat/Goat.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/goat/Goat.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/goat/Goat.java
++++ b/net/minecraft/world/entity/animal/goat/Goat.java
+@@ -64,7 +64,7 @@
+     private static final float BABY_SCALE = 0.55F;
+     private static final int ADULT_ATTACK_DAMAGE = 2;
+     private static final int BABY_ATTACK_DAMAGE = 1;
+-    private static final Brain.Provider<Goat> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Goat> BRAIN_PROVIDER = Brain.<Goat>provider(
+         List.of(
+             SensorType.NEAREST_LIVING_ENTITIES,
+             SensorType.NEAREST_PLAYERS,
+@@ -167,7 +167,7 @@
+ 
+     @Override
+     public Brain<Goat> getBrain() {
+-        return super.getBrain();
++        return (Brain<Goat>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/goat/GoatAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/goat/GoatAi.java.patch
@@ -1,0 +1,44 @@
+--- a/net/minecraft/world/entity/animal/goat/GoatAi.java
++++ b/net/minecraft/world/entity/animal/goat/GoatAi.java
+@@ -68,12 +68,12 @@
+     }
+ 
+     private static ActivityData<Goat> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Goat>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+                 new Swim<>(0.8F),
+-                new AnimalPanic(2.0F),
++                new AnimalPanic<Goat>(2.0F),
+                 new LookAtTargetSink(45, 90),
+                 new MoveToTargetSink(),
+                 new CountDownCooldownTicks(MemoryModuleType.TEMPTATION_COOLDOWN_TICKS),
+@@ -84,7 +84,7 @@
+     }
+ 
+     private static ActivityData<Goat> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Goat>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, SetEntityLookTargetSometimes.create(EntityTypes.PLAYER, 6.0F, UniformInt.of(30, 60))),
+@@ -107,7 +107,7 @@
+     }
+ 
+     private static ActivityData<Goat> initLongJumpActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Goat>create(
+             Activity.LONG_JUMP,
+             ImmutableList.of(
+                 Pair.of(0, new LongJumpMidJump(TIME_BETWEEN_LONG_JUMPS, SoundEvents.GOAT_STEP)),
+@@ -132,7 +132,7 @@
+     }
+ 
+     private static ActivityData<Goat> initRamActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Goat>create(
+             Activity.RAM,
+             ImmutableList.of(
+                 Pair.of(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/golem/CopperGolem.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/golem/CopperGolem.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/golem/CopperGolem.java
++++ b/net/minecraft/world/entity/animal/golem/CopperGolem.java
+@@ -153,7 +153,7 @@
+ 
+     @Override
+     public Brain<CopperGolem> getBrain() {
+-        return super.getBrain();
++        return (Brain<CopperGolem>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/golem/CopperGolemAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/golem/CopperGolemAi.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/golem/CopperGolemAi.java
++++ b/net/minecraft/world/entity/animal/golem/CopperGolemAi.java
+@@ -52,7 +52,7 @@
+     }
+ 
+     private static ActivityData<CopperGolem> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<CopperGolem>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -67,7 +67,7 @@
+     }
+ 
+     private static ActivityData<CopperGolem> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<CopperGolem>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/happyghast/HappyGhast.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/happyghast/HappyGhast.java
++++ b/net/minecraft/world/entity/animal/happyghast/HappyGhast.java
+@@ -64,7 +64,7 @@
+     public static final int MAX_PASSANGERS = 4;
+     private static final int STILL_TIMEOUT_ON_LOAD_GRACE_PERIOD = 60;
+     private static final int MAX_STILL_TIMEOUT = 10;
+-    private static final Brain.Provider<HappyGhast> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<HappyGhast> BRAIN_PROVIDER = Brain.<HappyGhast>provider(
+         List.of(
+             SensorType.NEAREST_LIVING_ENTITIES, SensorType.HURT_BY, SensorType.FOOD_TEMPTATIONS, SensorType.NEAREST_ADULT_ANY_TYPE, SensorType.NEAREST_PLAYERS
+         ),
+@@ -393,7 +393,7 @@
+ 
+     @Override
+     public Brain<HappyGhast> getBrain() {
+-        return super.getBrain();
++        return (Brain<HappyGhast>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/happyghast/HappyGhastAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/happyghast/HappyGhastAi.java.patch
@@ -1,0 +1,26 @@
+--- a/net/minecraft/world/entity/animal/happyghast/HappyGhastAi.java
++++ b/net/minecraft/world/entity/animal/happyghast/HappyGhastAi.java
+@@ -32,12 +32,12 @@
+     }
+ 
+     private static ActivityData<HappyGhast> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<HappyGhast>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+                 new Swim<>(0.8F),
+-                new AnimalPanic(2.0F, 0),
++                new AnimalPanic<HappyGhast>(2.0F, 0),
+                 new LookAtTargetSink(45, 90),
+                 new MoveToTargetSink(),
+                 new CountDownCooldownTicks(MemoryModuleType.TEMPTATION_COOLDOWN_TICKS)
+@@ -46,7 +46,7 @@
+     }
+ 
+     private static ActivityData<HappyGhast> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<HappyGhast>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(1, new FollowTemptation(mob -> 1.25F, mob -> 3.0, true)),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/Nautilus.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/Nautilus.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/nautilus/Nautilus.java
++++ b/net/minecraft/world/entity/animal/nautilus/Nautilus.java
+@@ -27,7 +27,7 @@
+         .getDimensions()
+         .scale(0.5F)
+         .withAttachments(EntityAttachments.builder().attach(EntityAttachment.PASSENGER, 0.0F, 0.5F, 0.0F));
+-    private static final Brain.Provider<Nautilus> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Nautilus> BRAIN_PROVIDER = Brain.<Nautilus>provider(
+         List.of(MemoryModuleType.ANGRY_AT, MemoryModuleType.ATTACK_TARGET_COOLDOWN),
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_ADULT, SensorType.NEAREST_PLAYERS, SensorType.HURT_BY, SensorType.NAUTILUS_TEMPTATIONS),
+         var0 -> NautilusAi.getActivities()
+@@ -44,7 +44,7 @@
+ 
+     @Override
+     public Brain<Nautilus> getBrain() {
+-        return super.getBrain();
++        return (Brain<Nautilus>)super.getBrain();
+     }
+ 
+     public @Nullable Nautilus getBreedOffspring(final ServerLevel level, final AgeableMob partner) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/NautilusAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/NautilusAi.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/nautilus/NautilusAi.java
++++ b/net/minecraft/world/entity/animal/nautilus/NautilusAi.java
+@@ -64,7 +64,7 @@
+     }
+ 
+     private static ActivityData<Nautilus> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Nautilus>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -79,7 +79,7 @@
+     }
+ 
+     private static ActivityData<Nautilus> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Nautilus>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(1, new AnimalMakeLove(EntityTypes.NAUTILUS, 0.4F, 2)),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/ZombieNautilus.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/ZombieNautilus.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/nautilus/ZombieNautilus.java
++++ b/net/minecraft/world/entity/animal/nautilus/ZombieNautilus.java
+@@ -35,7 +35,7 @@
+ import org.jspecify.annotations.Nullable;
+ 
+ public class ZombieNautilus extends AbstractNautilus {
+-    private static final Brain.Provider<ZombieNautilus> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<ZombieNautilus> BRAIN_PROVIDER = Brain.<ZombieNautilus>provider(
+         List.of(MemoryModuleType.ANGRY_AT, MemoryModuleType.ATTACK_TARGET_COOLDOWN),
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_ADULT, SensorType.NEAREST_PLAYERS, SensorType.HURT_BY, SensorType.NAUTILUS_TEMPTATIONS),
+         var0 -> ZombieNautilusAi.getActivities()
+@@ -68,7 +68,7 @@
+ 
+     @Override
+     public Brain<ZombieNautilus> getBrain() {
+-        return super.getBrain();
++        return (Brain<ZombieNautilus>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/ZombieNautilusAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/nautilus/ZombieNautilusAi.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/nautilus/ZombieNautilusAi.java
++++ b/net/minecraft/world/entity/animal/nautilus/ZombieNautilusAi.java
+@@ -34,7 +34,7 @@
+     }
+ 
+     private static ActivityData<ZombieNautilus> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<ZombieNautilus>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -48,7 +48,7 @@
+     }
+ 
+     private static ActivityData<ZombieNautilus> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<ZombieNautilus>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(1, new FollowTemptation(mob -> 0.9F, mob -> mob.isBaby() ? 2.5 : 3.5)),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/sniffer/Sniffer.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/sniffer/Sniffer.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/sniffer/Sniffer.java
++++ b/net/minecraft/world/entity/animal/sniffer/Sniffer.java
+@@ -61,7 +61,7 @@
+ import net.minecraft.world.phys.Vec3;
+ 
+ public class Sniffer extends Animal {
+-    private static final Brain.Provider<Sniffer> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Sniffer> BRAIN_PROVIDER = Brain.<Sniffer>provider(
+         List.of(MemoryModuleType.SNIFFER_EXPLORED_POSITIONS),
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.HURT_BY, SensorType.NEAREST_PLAYERS, SensorType.FOOD_TEMPTATIONS),
+         var0 -> SnifferAi.getActivities()
+@@ -448,7 +448,7 @@
+ 
+     @Override
+     public Brain<Sniffer> getBrain() {
+-        return super.getBrain();
++        return (Brain<Sniffer>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/sniffer/SnifferAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/animal/sniffer/SnifferAi.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/animal/sniffer/SnifferAi.java
++++ b/net/minecraft/world/entity/animal/sniffer/SnifferAi.java
+@@ -57,7 +57,7 @@
+     }
+ 
+     private static ActivityData<Sniffer> initCoreActivity() {
+-        return ActivityData.create(Activity.CORE, 0, ImmutableList.of(new Swim<>(0.8F), new AnimalPanic<Sniffer>(2.0F) {
++        return ActivityData.<Sniffer>create(Activity.CORE, 0, ImmutableList.of(new Swim<>(0.8F), new AnimalPanic<Sniffer>(2.0F) {
+             protected void start(final ServerLevel level, final Sniffer body, final long timestamp) {
+                 SnifferAi.resetSniffing(body);
+                 super.start(level, body, timestamp);
+@@ -90,7 +90,7 @@
+     }
+ 
+     private static ActivityData<Sniffer> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Sniffer>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, new AnimalMakeLove(EntityTypes.SNIFFER) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/Zoglin.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/Zoglin.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/entity/monster/Zoglin.java
++++ b/net/minecraft/world/entity/monster/Zoglin.java
+@@ -97,7 +97,7 @@
+     }
+ 
+     private static ActivityData<Zoglin> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Zoglin>create(
+             Activity.IDLE,
+             10,
+             ImmutableList.of(
+@@ -118,7 +118,7 @@
+     }
+ 
+     private static ActivityData<Zoglin> initFightActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Zoglin>create(
+             Activity.FIGHT,
+             10,
+             ImmutableList.of(
+@@ -221,7 +221,7 @@
+ 
+     @Override
+     public Brain<Zoglin> getBrain() {
+-        return super.getBrain();
++        return (Brain<Zoglin>)super.getBrain();
+     }
+ 
+     protected void updateActivity() {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/breeze/Breeze.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/breeze/Breeze.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/monster/breeze/Breeze.java
++++ b/net/minecraft/world/entity/monster/breeze/Breeze.java
+@@ -47,7 +47,7 @@
+     private static final float FALL_DISTANCE_SOUND_TRIGGER_THRESHOLD = 3.0F;
+     private static final int WHIRL_SOUND_FREQUENCY_MIN = 1;
+     private static final int WHIRL_SOUND_FREQUENCY_MAX = 80;
+-    private static final Brain.Provider<Breeze> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Breeze> BRAIN_PROVIDER = Brain.<Breeze>provider(
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.HURT_BY, SensorType.NEAREST_PLAYERS, SensorType.BREEZE_ATTACK_ENTITY_SENSOR),
+         BreezeAi::getActivities
+     );
+@@ -81,7 +81,7 @@
+ 
+     @Override
+     public Brain<Breeze> getBrain() {
+-        return super.getBrain();
++        return (Brain<Breeze>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/breeze/BreezeAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/breeze/BreezeAi.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/world/entity/monster/breeze/BreezeAi.java
++++ b/net/minecraft/world/entity/monster/breeze/BreezeAi.java
+@@ -38,11 +38,11 @@
+     }
+ 
+     private static ActivityData<Breeze> initCoreActivity() {
+-        return ActivityData.create(Activity.CORE, 0, ImmutableList.of(new Swim<>(0.8F), new LookAtTargetSink(45, 90)));
++        return ActivityData.<Breeze>create(Activity.CORE, 0, ImmutableList.of(new Swim<>(0.8F), new LookAtTargetSink(45, 90)));
+     }
+ 
+     private static ActivityData<Breeze> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Breeze>create(
+             Activity.IDLE,
+             ImmutableList.of(
+                 Pair.of(0, StartAttacking.create((var0, breeze) -> breeze.getBrain().getMemory(MemoryModuleType.NEAREST_ATTACKABLE))),
+@@ -63,7 +63,7 @@
+     }
+ 
+     private static ActivityData<Breeze> initFightActivity(final Breeze body) {
+-        return ActivityData.create(
++        return ActivityData.<Breeze>create(
+             Activity.FIGHT,
+             ImmutableList.of(
+                 Pair.of(0, StopAttackingIfTargetInvalid.create(Sensor.wasEntityAttackableLastNTicks(body, 100).negate()::test)),

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/creaking/Creaking.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/creaking/Creaking.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/creaking/Creaking.java
++++ b/net/minecraft/world/entity/monster/creaking/Creaking.java
+@@ -200,7 +200,7 @@
+ 
+     @Override
+     public Brain<Creaking> getBrain() {
+-        return super.getBrain();
++        return (Brain<Creaking>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/creaking/CreakingAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/creaking/CreakingAi.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/entity/monster/creaking/CreakingAi.java
++++ b/net/minecraft/world/entity/monster/creaking/CreakingAi.java
+@@ -28,7 +28,7 @@
+ 
+ public class CreakingAi {
+     private static ActivityData<Creaking> initCoreActivity() {
+-        return ActivityData.create(Activity.CORE, 0, ImmutableList.of(new Swim<Creaking>(0.8F) {
++        return ActivityData.<Creaking>create(Activity.CORE, 0, ImmutableList.of(new Swim<Creaking>(0.8F) {
+             protected boolean checkExtraStartConditions(final ServerLevel level, final Creaking body) {
+                 return body.canMove() && super.checkExtraStartConditions(level, body);
+             }
+@@ -36,7 +36,7 @@
+     }
+ 
+     private static ActivityData<Creaking> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Creaking>create(
+             Activity.IDLE,
+             10,
+             ImmutableList.of(
+@@ -54,7 +54,7 @@
+     }
+ 
+     private static ActivityData<Creaking> initFightActivity(final Creaking body) {
+-        return ActivityData.create(
++        return ActivityData.<Creaking>create(
+             Activity.FIGHT,
+             10,
+             ImmutableList.of(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/monster/hoglin/Hoglin.java
++++ b/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+@@ -70,7 +70,7 @@
+     private int attackAnimationRemainingTicks;
+     private int timeInOverworld = 0;
+     private boolean cannotBeHunted = false;
+-    private static final Brain.Provider<Hoglin> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Hoglin> BRAIN_PROVIDER = Brain.<Hoglin>provider(
+         List.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_PLAYERS, SensorType.NEAREST_ADULT, SensorType.HOGLIN_SPECIFIC_SENSOR),
+         var0 -> HoglinAi.getActivities()
+     );
+@@ -136,7 +136,7 @@
+ 
+     @Override
+     public Brain<Hoglin> getBrain() {
+-        return super.getBrain();
++        return (Brain<Hoglin>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/hoglin/HoglinAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/hoglin/HoglinAi.java.patch
@@ -1,0 +1,37 @@
+--- a/net/minecraft/world/entity/monster/hoglin/HoglinAi.java
++++ b/net/minecraft/world/entity/monster/hoglin/HoglinAi.java
+@@ -64,7 +64,7 @@
+     }
+ 
+     private static ActivityData<Hoglin> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Hoglin>create(
+             Activity.IDLE,
+             10,
+             ImmutableList.of(
+@@ -81,7 +81,7 @@
+     }
+ 
+     private static ActivityData<Hoglin> initFightActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Hoglin>create(
+             Activity.FIGHT,
+             10,
+             ImmutableList.of(
+@@ -98,14 +98,14 @@
+     }
+ 
+     private static ActivityData<Hoglin> initRetreatActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Hoglin>create(
+             Activity.AVOID,
+             10,
+             ImmutableList.of(
+                 SetWalkTargetAwayFrom.entity(MemoryModuleType.AVOID_TARGET, 1.3F, 15, false),
+                 createIdleMovementBehaviors(),
+                 SetEntityLookTargetSometimes.create(8.0F, UniformInt.of(30, 60)),
+-                EraseMemoryIf.<PathfinderMob>create(HoglinAi::wantsToStopFleeing, MemoryModuleType.AVOID_TARGET)
++                EraseMemoryIf.create(HoglinAi::wantsToStopFleeing, MemoryModuleType.AVOID_TARGET)
+             ),
+             MemoryModuleType.AVOID_TARGET
+         );

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/monster/piglin/Piglin.java
++++ b/net/minecraft/world/entity/monster/piglin/Piglin.java
+@@ -85,7 +85,7 @@
+     private static final int INVENTORY_SIZE = 8;
+     private final SimpleContainer inventory = new SimpleContainer(8);
+     private boolean cannotHunt = false;
+-    private static final Brain.Provider<Piglin> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Piglin> BRAIN_PROVIDER = Brain.<Piglin>provider(
+         List.of(
+             MemoryModuleType.UNIVERSAL_ANGER,
+             MemoryModuleType.ATE_RECENTLY,
+@@ -218,7 +218,7 @@
+ 
+     @Override
+     public Brain<Piglin> getBrain() {
+-        return super.getBrain();
++        return (Brain<Piglin>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/PiglinAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/PiglinAi.java.patch
@@ -1,0 +1,99 @@
+--- a/net/minecraft/world/entity/monster/piglin/PiglinAi.java
++++ b/net/minecraft/world/entity/monster/piglin/PiglinAi.java
+@@ -134,7 +134,7 @@
+     }
+ 
+     private static ActivityData<Piglin> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Piglin>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(
+@@ -152,7 +152,7 @@
+     }
+ 
+     private static ActivityData<Piglin> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Piglin>create(
+             Activity.IDLE,
+             10,
+             ImmutableList.of(
+@@ -169,7 +169,7 @@
+     }
+ 
+     private static ActivityData<Piglin> initFightActivity(final Piglin body) {
+-        return ActivityData.create(
++        return ActivityData.<Piglin>create(
+             Activity.FIGHT,
+             10,
+             ImmutableList.of(
+@@ -180,7 +180,7 @@
+                 new SpearAttack(1.0, 1.0, 2.0F),
+                 new SpearRetreat(1.0),
+                 MeleeAttack.create(20),
+-                new CrossbowAttack(),
++                new CrossbowAttack<>(),
+                 RememberIfHoglinWasKilled.create(),
+                 EraseMemoryIf.create(PiglinAi::isNearZombified, MemoryModuleType.ATTACK_TARGET)
+             ),
+@@ -189,7 +189,7 @@
+     }
+ 
+     private static ActivityData<Piglin> initCelebrateActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Piglin>create(
+             Activity.CELEBRATE,
+             10,
+             ImmutableList.of(
+@@ -198,7 +198,7 @@
+                 StartAttacking.<Piglin>create((level, piglin) -> piglin.isAdult(), PiglinAi::findNearestValidAttackTarget),
+                 BehaviorBuilder.triggerIf(piglin -> !piglin.isDancing(), GoToTargetLocation.create(MemoryModuleType.CELEBRATE_LOCATION, 2, 1.0F)),
+                 BehaviorBuilder.triggerIf(Piglin::isDancing, GoToTargetLocation.create(MemoryModuleType.CELEBRATE_LOCATION, 4, 0.6F)),
+-                new RunOne<LivingEntity>(
++                new RunOne<Piglin>(
+                     ImmutableList.of(
+                         Pair.of(SetEntityLookTarget.create(EntityTypes.PIGLIN, 8.0F), 1),
+                         Pair.of(RandomStroll.stroll(0.6F, 2, 1), 1),
+@@ -211,7 +211,7 @@
+     }
+ 
+     private static ActivityData<Piglin> initAdmireItemActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Piglin>create(
+             Activity.ADMIRE_ITEM,
+             10,
+             ImmutableList.of(
+@@ -224,21 +224,21 @@
+     }
+ 
+     private static ActivityData<Piglin> initRetreatActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Piglin>create(
+             Activity.AVOID,
+             10,
+             ImmutableList.of(
+                 SetWalkTargetAwayFrom.entity(MemoryModuleType.AVOID_TARGET, 1.0F, 12, true),
+                 createIdleLookBehaviors(),
+                 createIdleMovementBehaviors(),
+-                EraseMemoryIf.<PathfinderMob>create(PiglinAi::wantsToStopFleeing, MemoryModuleType.AVOID_TARGET)
++                EraseMemoryIf.<Piglin>create(PiglinAi::wantsToStopFleeing, MemoryModuleType.AVOID_TARGET)
+             ),
+             MemoryModuleType.AVOID_TARGET
+         );
+     }
+ 
+     private static ActivityData<Piglin> initRideHoglinActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Piglin>create(
+             Activity.RIDE,
+             10,
+             ImmutableList.of(
+@@ -253,7 +253,7 @@
+                             .build()
+                     )
+                 ),
+-                DismountOrSkipMounting.<LivingEntity>create(8, PiglinAi::wantsToStopRiding)
++                DismountOrSkipMounting.<Piglin>create(8, PiglinAi::wantsToStopRiding)
+             ),
+             MemoryModuleType.RIDE_TARGET
+         );

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/PiglinBrute.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/PiglinBrute.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/monster/piglin/PiglinBrute.java
++++ b/net/minecraft/world/entity/monster/piglin/PiglinBrute.java
+@@ -33,7 +33,7 @@
+     private static final float MOVEMENT_SPEED_WHEN_FIGHTING = 0.35F;
+     private static final int ATTACK_DAMAGE = 7;
+     private static final double TARGETING_RANGE = 12.0;
+-    public static final Brain.Provider<PiglinBrute> BRAIN_PROVIDER = Brain.provider(
++    public static final Brain.Provider<PiglinBrute> BRAIN_PROVIDER = Brain.<PiglinBrute>provider(
+         List.of(MemoryModuleType.NEAREST_VISIBLE_ADULT_PIGLINS),
+         List.of(
+             SensorType.NEAREST_LIVING_ENTITIES,
+@@ -79,7 +79,7 @@
+ 
+     @Override
+     public Brain<PiglinBrute> getBrain() {
+-        return super.getBrain();
++        return (Brain<PiglinBrute>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/PiglinBruteAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/PiglinBruteAi.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/entity/monster/piglin/PiglinBruteAi.java
++++ b/net/minecraft/world/entity/monster/piglin/PiglinBruteAi.java
+@@ -52,7 +52,7 @@
+     }
+ 
+     private static ActivityData<PiglinBrute> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<PiglinBrute>create(
+             Activity.CORE,
+             0,
+             ImmutableList.of(new LookAtTargetSink(45, 90), new MoveToTargetSink(), InteractWithDoor.create(), StopBeingAngryIfTargetDead.create())
+@@ -60,7 +60,7 @@
+     }
+ 
+     private static ActivityData<PiglinBrute> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<PiglinBrute>create(
+             Activity.IDLE,
+             10,
+             ImmutableList.of(
+@@ -73,7 +73,7 @@
+     }
+ 
+     private static ActivityData<PiglinBrute> initFightActivity(final PiglinBrute body) {
+-        return ActivityData.create(
++        return ActivityData.<PiglinBrute>create(
+             Activity.FIGHT,
+             10,
+             ImmutableList.of(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java
++++ b/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java
+@@ -16,12 +16,12 @@
+                     i.registered(MemoryModuleType.NEAREST_VISIBLE_ADULT_PIGLINS)
+                 )
+                 .apply(i, (huntable, angryAt, huntedRecently, nearestPiglins) -> (level, body, timestamp) -> {
+-                    if (!body.isBaby() && !i.<List>tryGet(nearestPiglins).filter(p -> p.stream().anyMatch(StartHuntingHoglin::hasHuntedRecently)).isPresent()) {
++                    if (!body.isBaby() && !i.tryGet(nearestPiglins).filter(p -> p.stream().anyMatch(StartHuntingHoglin::hasHuntedRecently)).isPresent()) {
+                         Hoglin target = i.get(huntable);
+                         PiglinAi.setAngerTarget(level, body, target);
+                         PiglinAi.dontKillAnyMoreHoglinsForAWhile(body);
+                         PiglinAi.broadcastAngerTarget(level, body, target);
+-                        i.<List>tryGet(nearestPiglins).ifPresent(p -> p.forEach(PiglinAi::dontKillAnyMoreHoglinsForAWhile));
++                        i.tryGet(nearestPiglins).ifPresent(p -> p.forEach(PiglinAi::dontKillAnyMoreHoglinsForAWhile));
+                         return true;
+                     } else {
+                         return false;

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/warden/Warden.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/warden/Warden.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/monster/warden/Warden.java
++++ b/net/minecraft/world/entity/monster/warden/Warden.java
+@@ -97,7 +97,7 @@
+     private static final float DIGGING_PARTICLES_DURATION = 4.5F;
+     private static final float DIGGING_PARTICLES_OFFSET = 0.7F;
+     private static final int PROJECTILE_ANGER_DISTANCE = 30;
+-    private static final Brain.Provider<Warden> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Warden> BRAIN_PROVIDER = Brain.<Warden>provider(
+         List.of(
+             MemoryModuleType.NEAREST_VISIBLE_NEMESIS, MemoryModuleType.RECENT_PROJECTILE, MemoryModuleType.TOUCH_COOLDOWN, MemoryModuleType.VIBRATION_COOLDOWN
+         ),
+@@ -378,7 +378,7 @@
+ 
+     @Override
+     public Brain<Warden> getBrain() {
+-        return super.getBrain();
++        return (Brain<Warden>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/warden/WardenAi.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/monster/warden/WardenAi.java.patch
@@ -1,0 +1,47 @@
+--- a/net/minecraft/world/entity/monster/warden/WardenAi.java
++++ b/net/minecraft/world/entity/monster/warden/WardenAi.java
+@@ -81,7 +81,7 @@
+     }
+ 
+     private static ActivityData<Warden> initCoreActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Warden>create(
+             Activity.CORE, 0, ImmutableList.of(new Swim<>(0.8F), SetWardenLookTarget.create(), new LookAtTargetSink(45, 90), new MoveToTargetSink())
+         );
+     }
+@@ -91,7 +91,7 @@
+     }
+ 
+     private static ActivityData<Warden> initDiggingActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Warden>create(
+             Activity.DIG,
+             ImmutableList.of(Pair.of(0, new ForceUnmount()), Pair.of(1, new Digging<>(DIGGING_DURATION))),
+             ImmutableSet.of(Pair.of(MemoryModuleType.ROAR_TARGET, MemoryStatus.VALUE_ABSENT), Pair.of(MemoryModuleType.DIG_COOLDOWN, MemoryStatus.VALUE_ABSENT))
+@@ -99,7 +99,7 @@
+     }
+ 
+     private static ActivityData<Warden> initIdleActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Warden>create(
+             Activity.IDLE,
+             10,
+             ImmutableList.of(
+@@ -114,7 +114,7 @@
+     }
+ 
+     private static ActivityData<Warden> initInvestigateActivity() {
+-        return ActivityData.create(
++        return ActivityData.<Warden>create(
+             Activity.INVESTIGATE,
+             5,
+             ImmutableList.of(SetRoarTarget.create(Warden::getEntityAngryAt), GoToTargetLocation.create(MemoryModuleType.DISTURBANCE_LOCATION, 2, 0.7F)),
+@@ -136,7 +136,7 @@
+     }
+ 
+     private static ActivityData<Warden> initFightActivity(final Warden body) {
+-        return ActivityData.create(
++        return ActivityData.<Warden>create(
+             Activity.FIGHT,
+             10,
+             ImmutableList.of(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/npc/villager/Villager.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/npc/villager/Villager.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/npc/villager/Villager.java
++++ b/net/minecraft/world/entity/npc/villager/Villager.java
+@@ -126,7 +126,7 @@
+     private int numberOfRestocksToday = 0;
+     private long lastRestockCheckDay;
+     private boolean assignProfessionWhenSpawned = false;
+-    private static final Brain.Provider<Villager> BRAIN_PROVIDER = Brain.provider(
++    private static final Brain.Provider<Villager> BRAIN_PROVIDER = Brain.<Villager>provider(
+         List.of(
+             SensorType.NEAREST_LIVING_ENTITIES,
+             SensorType.NEAREST_PLAYERS,
+@@ -191,7 +191,7 @@
+ 
+     @Override
+     public Brain<Villager> getBrain() {
+-        return super.getBrain();
++        return (Brain<Villager>)super.getBrain();
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/npc/villager/Villager.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/npc/villager/Villager.java.patch
@@ -1,9 +1,8 @@
 --- a/net/minecraft/world/entity/npc/villager/Villager.java
 +++ b/net/minecraft/world/entity/npc/villager/Villager.java
-@@ -126,7 +126,7 @@
+@@ -125,6 +125,6 @@
      private int numberOfRestocksToday = 0;
      private long lastRestockCheckDay;
-     private boolean assignProfessionWhenSpawned = false;
 -    private static final Brain.Provider<Villager> BRAIN_PROVIDER = Brain.provider(
 +    private static final Brain.Provider<Villager> BRAIN_PROVIDER = Brain.<Villager>provider(
          List.of(

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/variant/PriorityProvider.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/entity/variant/PriorityProvider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/variant/PriorityProvider.java
++++ b/net/minecraft/world/entity/variant/PriorityProvider.java
+@@ -103,7 +103,7 @@
+     }
+ 
+     record UnpackedEntry<C, T>(T entry, int priority, PriorityProvider.SelectorCondition<C> condition) {
+-        public static final Comparator<PriorityProvider.UnpackedEntry<?, ?>> HIGHEST_PRIORITY_FIRST = Comparator.comparingInt(
++        public static final Comparator<PriorityProvider.UnpackedEntry<?, ?>> HIGHEST_PRIORITY_FIRST = Comparator.<PriorityProvider.UnpackedEntry<?, ?>>comparingInt(
+                 PriorityProvider.UnpackedEntry::priority
+             )
+             .reversed();

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/AdventureModePredicate.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/AdventureModePredicate.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/AdventureModePredicate.java
++++ b/net/minecraft/world/item/AdventureModePredicate.java
+@@ -116,7 +116,7 @@
+         return predicates.stream()
+             .flatMap(predicatex -> predicatex.blocks().orElseThrow().stream())
+             .distinct()
+-            .map(block -> block.value().getName().withStyle(ChatFormatting.DARK_GRAY))
++            .map(block -> (Component)block.value().getName().withStyle(ChatFormatting.DARK_GRAY))
+             .toList();
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/HoneycombItem.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/HoneycombItem.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/HoneycombItem.java
++++ b/net/minecraft/world/item/HoneycombItem.java
+@@ -66,7 +66,7 @@
+         Level level = context.getLevel();
+         BlockPos pos = context.getClickedPos();
+         BlockState oldState = level.getBlockState(pos);
+-        return getWaxed(oldState).map(waxedState -> {
++        return getWaxed(oldState).<InteractionResult>map(waxedState -> {
+             Player player = context.getPlayer();
+             ItemStack itemInHand = context.getItemInHand();
+             if (player instanceof ServerPlayer serverPlayer) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/component/KineticWeapon.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/component/KineticWeapon.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/component/KineticWeapon.java
++++ b/net/minecraft/world/item/component/KineticWeapon.java
+@@ -112,7 +112,7 @@
+             for (EntityHitResult hitResult : ProjectileUtil.getHitEntitiesAlong(
+                     livingEntity, attackRange, e -> PiercingWeapon.canHitEntity(livingEntity, e), ClipContext.Block.COLLIDER
+                 )
+-                .map(a -> List.of(), e -> (Collection)e)) {
++                .map(a -> List.<EntityHitResult>of(), e -> (Collection<EntityHitResult>)e)) {
+                 Entity otherEntity = hitResult.getEntity();
+                 if (otherEntity instanceof EnderDragonPart dragonPart) {
+                     otherEntity = dragonPart.parentMob;

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/component/PiercingWeapon.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/component/PiercingWeapon.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/component/PiercingWeapon.java
++++ b/net/minecraft/world/item/component/PiercingWeapon.java
+@@ -79,7 +79,7 @@
+         boolean hitSomething = false;
+ 
+         for (EntityHitResult hitResult : ProjectileUtil.getHitEntitiesAlong(attacker, attackRange, e1 -> canHitEntity(attacker, e1), ClipContext.Block.COLLIDER)
+-            .map(a -> List.of(), e -> (Collection)e)) {
++            .map(a -> List.<EntityHitResult>of(), e -> (Collection<EntityHitResult>)e)) {
+             hitSomething |= attacker.stabAttack(hand, hitResult.getEntity(), damage, true, this.dealsKnockback, this.dismounts);
+         }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/crafting/RecipeMap.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/item/crafting/RecipeMap.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/crafting/RecipeMap.java
++++ b/net/minecraft/world/item/crafting/RecipeMap.java
+@@ -34,7 +34,7 @@
+     }
+ 
+     public <I extends RecipeInput, T extends Recipe<I>> Collection<RecipeHolder<T>> byType(final RecipeType<T> type) {
+-        return (Collection<RecipeHolder<T>>)this.byType.get(type);
++        return (Collection<RecipeHolder<T>>)(Collection)this.byType.get(type);
+     }
+ 
+     public Collection<RecipeHolder<?>> values() {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/biome/Climate.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/biome/Climate.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/biome/Climate.java
++++ b/net/minecraft/world/level/biome/Climate.java
+@@ -271,7 +271,7 @@
+             }
+ 
+             List<Climate.RTree.Leaf<T>> leaves = values.stream()
+-                .map(p -> new Climate.RTree.Leaf(p.getFirst(), p.getSecond()))
++                .map(p -> new Climate.RTree.Leaf<T>(p.getFirst(), p.getSecond()))
+                 .collect(Collectors.toCollection(ArrayList::new));
+             return new Climate.RTree<>(build(dimensions, leaves));
+         }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/block/BaseEntityBlock.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/block/BaseEntityBlock.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/level/block/BaseEntityBlock.java
++++ b/net/minecraft/world/level/block/BaseEntityBlock.java
+@@ -34,6 +34,6 @@
+     protected static <E extends BlockEntity, A extends BlockEntity> @Nullable BlockEntityTicker<A> createTickerHelper(
+         final BlockEntityType<A> actual, final BlockEntityType<E> expected, final @Nullable BlockEntityTicker<? super E> ticker
+     ) {
+-        return expected == actual ? ticker : null;
++        return expected == actual ? (BlockEntityTicker<A>)ticker : null;
+     }
+ }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/block/Block.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/block/Block.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/Block.java
++++ b/net/minecraft/world/level/block/Block.java
+@@ -605,7 +605,7 @@
+     }
+ 
+     private static <S extends StateHolder<?, S>, T extends Comparable<T>> S setValueHelper(final S state, final Property<T> property, final Object value) {
+-        return state.setValue(property, (Comparable)value);
++        return state.setValue(property, (T)value);
+     }
+ 
+     @Deprecated

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/block/entity/TestInstanceBlockEntity.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/block/entity/TestInstanceBlockEntity.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/entity/TestInstanceBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/TestInstanceBlockEntity.java
+@@ -107,7 +107,7 @@
+     }
+ 
+     public Component getTestName() {
+-        return this.test().map(key -> Component.literal(key.identifier().toString())).orElse(INVALID_TEST_NAME);
++        return this.test().<Component>map(key -> Component.literal(key.identifier().toString())).orElse(INVALID_TEST_NAME);
+     }
+ 
+     private Optional<Holder.Reference<GameTestInstance>> getTestHolder() {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/dimension/end/EnderDragonFight.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/dimension/end/EnderDragonFight.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/dimension/end/EnderDragonFight.java
++++ b/net/minecraft/world/level/dimension/end/EnderDragonFight.java
+@@ -112,7 +112,7 @@
+                 UUIDUtil.CODEC.lenientOptionalFieldOf("dragon_uuid").forGetter(fight -> Optional.ofNullable(fight.dragonUUID)),
+                 BlockPos.CODEC.lenientOptionalFieldOf("exit_portal_location").forGetter(fight -> Optional.ofNullable(fight.exitPortalLocation)),
+                 Codec.list(Codec.INT).lenientOptionalFieldOf("gateways", new ArrayList<>()).forGetter(fight -> fight.gateways),
+-                Codec.list(EntityReference.codec()).optionalFieldOf("respawn_crystals", List.of()).forGetter(fight -> fight.respawnCrystals)
++                Codec.list(EntityReference.<EndCrystal>codec()).optionalFieldOf("respawn_crystals", List.of()).forGetter(fight -> fight.respawnCrystals)
+             )
+             .apply(i, EnderDragonFight::new)
+     );

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/entity/EntitySectionStorage.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/entity/EntitySectionStorage.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/entity/EntitySectionStorage.java
++++ b/net/minecraft/world/level/entity/EntitySectionStorage.java
+@@ -107,7 +107,7 @@
+ 
+     public LongSet getAllChunksWithExistingSections() {
+         LongSet chunks = new LongOpenHashSet();
+-        this.sections.keySet().forEach(sectionKey -> chunks.add(getChunkKeyFromSectionKey(sectionKey)));
++        this.sections.keySet().forEach((long sectionKey) -> chunks.add(getChunkKeyFromSectionKey(sectionKey)));
+         return chunks;
+     }
+ 

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/entity/PersistentEntitySectionManager.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/entity/PersistentEntitySectionManager.java.patch
@@ -1,0 +1,44 @@
+--- a/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
++++ b/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
+@@ -226,7 +226,7 @@
+     }
+ 
+     private void processUnloads() {
+-        this.chunksToUnload.removeIf(chunkKey -> this.chunkVisibility.get(chunkKey) != Visibility.HIDDEN ? true : this.processChunkUnload(chunkKey));
++        this.chunksToUnload.removeIf((long chunkKey) -> this.chunkVisibility.get(chunkKey) != Visibility.HIDDEN ? true : this.processChunkUnload(chunkKey));
+     }
+ 
+     public void processPendingLoads() {
+@@ -255,7 +255,7 @@
+     }
+ 
+     public void autoSave() {
+-        this.getAllChunksToSave().forEach(chunkKey -> {
++        this.getAllChunksToSave().forEach((long chunkKey) -> {
+             boolean shouldUnload = this.chunkVisibility.get(chunkKey) == Visibility.HIDDEN;
+             if (shouldUnload) {
+                 this.processChunkUnload(chunkKey);
+@@ -271,7 +271,7 @@
+         while (!chunksToSave.isEmpty()) {
+             this.permanentStorage.flush(false);
+             this.processPendingLoads();
+-            chunksToSave.removeIf(chunkKey -> {
++            chunksToSave.removeIf((long chunkKey) -> {
+                 boolean shouldUnload = this.chunkVisibility.get(chunkKey) == Visibility.HIDDEN;
+                 return shouldUnload ? this.processChunkUnload(chunkKey) : this.storeChunkSections(chunkKey, e -> {});
+             });
+@@ -318,12 +318,12 @@
+         this.sectionStorage
+             .getAllChunksWithExistingSections()
+             .forEach(
+-                chunkKey -> {
++                (long chunkKey) -> {
+                     PersistentEntitySectionManager.ChunkLoadStatus loadStatus = this.chunkLoadStatuses.get(chunkKey);
+                     this.sectionStorage
+                         .getExistingSectionPositionsInChunk(chunkKey)
+                         .forEach(
+-                            sectionKey -> {
++                            (long sectionKey) -> {
+                                 EntitySection<T> section = this.sectionStorage.getSection(sectionKey);
+                                 if (section != null) {
+                                     try {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/gamerules/GameRuleMap.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/gamerules/GameRuleMap.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/gamerules/GameRuleMap.java
++++ b/net/minecraft/world/level/gamerules/GameRuleMap.java
+@@ -16,7 +16,7 @@
+ import org.jspecify.annotations.Nullable;
+ 
+ public final class GameRuleMap extends SavedData {
+-    public static final Codec<GameRuleMap> CODEC = Codec.dispatchedMap(BuiltInRegistries.GAME_RULE.byNameCodec(), GameRule::valueCodec)
++    public static final Codec<GameRuleMap> CODEC = Codec.<GameRule<?>, Object>dispatchedMap(BuiltInRegistries.GAME_RULE.byNameCodec(), GameRule::valueCodec)
+         .xmap(GameRuleMap::ofTrusted, GameRuleMap::map);
+     public static final SavedDataType<GameRuleMap> TYPE = new SavedDataType<>(
+         Identifier.withDefaultNamespace("game_rules"), GameRuleMap::of, CODEC, DataFixTypes.SAVED_DATA_GAME_RULES

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java.patch
@@ -1,11 +1,11 @@
 --- a/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java
 +++ b/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java
-@@ -27,7 +27,7 @@
-         } else if (!(config.placeBlock instanceof MultifaceSpreadeableBlock placerBlock)) {
+@@ -65,7 +65,7 @@
+         } else if (!(this.placeBlock instanceof MultifaceSpreadeableBlock placerBlock)) {
              return false;
          } else {
--            List var14 = config.getShuffledDirections(random);
-+            List<Direction> var14 = config.getShuffledDirections(random);
-             if (placeGrowthIfPossible(placerBlock, level, origin, level.getBlockState(origin), config, random, var14)) {
+-            List var13 = this.getShuffledDirections(random);
++            List<Direction> var13 = this.getShuffledDirections(random);
+             if (this.placeGrowthIfPossible(placerBlock, level, origin, level.getBlockState(origin), random, var13)) {
                  return true;
              }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java
++++ b/net/minecraft/world/level/levelgen/feature/MultifaceGrowthFeature.java
+@@ -27,7 +27,7 @@
+         } else if (!(config.placeBlock instanceof MultifaceSpreadeableBlock placerBlock)) {
+             return false;
+         } else {
+-            List var14 = config.getShuffledDirections(random);
++            List<Direction> var14 = config.getShuffledDirections(random);
+             if (placeGrowthIfPossible(placerBlock, level, origin, level.getBlockState(origin), config, random, var14)) {
+                 return true;
+             }

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/lighting/DynamicGraphMinFixedPoint.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/lighting/DynamicGraphMinFixedPoint.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/level/lighting/DynamicGraphMinFixedPoint.java
++++ b/net/minecraft/world/level/lighting/DynamicGraphMinFixedPoint.java
+@@ -45,12 +45,12 @@
+ 
+     public void removeIf(final LongPredicate pred) {
+         LongList nodesToRemove = new LongArrayList();
+-        this.computedLevels.keySet().forEach(node -> {
++        this.computedLevels.keySet().forEach((long node) -> {
+             if (pred.test(node)) {
+                 nodesToRemove.add(node);
+             }
+         });
+-        nodesToRemove.forEach(this::removeFromQueue);
++        nodesToRemove.forEach((java.util.function.LongConsumer)this::removeFromQueue);
+     }
+ 
+     private int calculatePriority(final int level, final int computedLevel) {

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/storage/loot/functions/SetCustomModelDataFunction.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/storage/loot/functions/SetCustomModelDataFunction.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/functions/SetCustomModelDataFunction.java
++++ b/net/minecraft/world/level/storage/loot/functions/SetCustomModelDataFunction.java
+@@ -20,7 +20,7 @@
+ 
+ public class SetCustomModelDataFunction extends LootItemConditionalFunction {
+     private static final Codec<NumberProvider> COLOR_PROVIDER_CODEC = Codec.withAlternative(
+-        NumberProviders.CODEC, ExtraCodecs.RGB_COLOR_CODEC, ConstantValue::new
++        NumberProviders.CODEC, ExtraCodecs.RGB_COLOR_CODEC, value -> new ConstantValue(value)
+     );
+     public static final MapCodec<SetCustomModelDataFunction> MAP_CODEC = RecordCodecBuilder.mapCodec(
+         i -> commonFields(i)

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/storage/loot/predicates/EnvironmentAttributeCheck.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/storage/loot/predicates/EnvironmentAttributeCheck.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/predicates/EnvironmentAttributeCheck.java
++++ b/net/minecraft/world/level/storage/loot/predicates/EnvironmentAttributeCheck.java
+@@ -20,7 +20,7 @@
+ 
+     @Override
+     public MapCodec<EnvironmentAttributeCheck<Value>> codec() {
+-        return (MapCodec<EnvironmentAttributeCheck<Value>>)MAP_CODEC;
++        return (MapCodec<EnvironmentAttributeCheck<Value>>)(MapCodec)MAP_CODEC;
+     }
+ 
+     @Override

--- a/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/storage/loot/predicates/LootItemBlockStatePropertyCondition.java.patch
+++ b/versions/pre/26/26.3-snapshot-2/patches/shared/net/minecraft/world/level/storage/loot/predicates/LootItemBlockStatePropertyCondition.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/predicates/LootItemBlockStatePropertyCondition.java
++++ b/net/minecraft/world/level/storage/loot/predicates/LootItemBlockStatePropertyCondition.java
+@@ -27,7 +27,7 @@
+     private static DataResult<LootItemBlockStatePropertyCondition> validate(final LootItemBlockStatePropertyCondition condition) {
+         return condition.properties()
+             .flatMap(properties -> properties.checkState(condition.block().value().getStateDefinition()))
+-            .map(name -> DataResult.error(() -> "Block " + condition.block() + " has no property" + name))
++            .map(name -> DataResult.<LootItemBlockStatePropertyCondition>error(() -> "Block " + condition.block() + " has no property" + name))
+             .orElse(DataResult.success(condition));
+     }
+ 


### PR DESCRIPTION
NOTE: This PR needs the PR from SrgUtils (https://github.com/MinecraftForge/SrgUtils/pull/25) to be merged before this can be merged as there is a temporary fix to build the SrgUtils locally with the updated snapshots.


This pull request introduces several improvements and fixes across the build configuration and client patch files, primarily to update dependencies, add support for a new pre-release version (`26.3-snapshot-2`), and resolve various type and logging issues in the codebase.

**Dependency and Build System Updates:**

- Updated the `net.minecraftforge:srgutils` dependency from version `0.6.2` to `0.6.6` in `buildSrc/build.gradle` and added dependency substitution to use a local `SrgUtils` project in both `buildSrc/settings.gradle` and `settings.gradle`. [[1]](diffhunk://#diff-bc7a42af0a917334e95bb43c1ac3408e14a03a45ef844e044089d4dc233d5b74L12-R12) [[2]](diffhunk://#diff-c09666b71b500cee7a6d27206ddf1910c82e267cd3b3986256165e73ab313eb8R1-R5) [[3]](diffhunk://#diff-7f825392aa37acd1cee0c2e7b9bb7366ad6eac64f3e6cdd816e156bcb69d30deR7-R12)
- Added a new configuration and dependency for `mappingToyClasspath` in `update.gradle`, and updated the `runMappingToy` task to use this configuration. [[1]](diffhunk://#diff-3402f3dc122aeee0d011f36749d8aa4b2cf7018ca212e95fa015f90b5a0e6001R9-R16) [[2]](diffhunk://#diff-3402f3dc122aeee0d011f36749d8aa4b2cf7018ca212e95fa015f90b5a0e6001R43)

**New Version Support:**

- Added configuration and support files for `versions/pre/26/26.3-snapshot-2`, including a new `config.json` and a `Start.java` entrypoint for launching the client. [[1]](diffhunk://#diff-d1f0fd1f474b933dc9aeb226989bcab78635260db0e45f35cfc20cf34e051364R1-R31) [[2]](diffhunk://#diff-3771e8d3546b660346b8a3161dcfe2fc97c0981f6e41e63d6761d711c16a7544R1-R94)

**Client Patch Fixes and Improvements:**

_Type Safety and Type Casting:_

- Fixed or added explicit type casts in several patch files to resolve type inference and generic issues, such as in `OptionInstance.java`, `PresetFlatWorldScreen.java`, `WorldCreationUiState.java`, `BookViewScreen.java`, `ChatComponent.java`, and `ModelFeatureRenderer.java`. [[1]](diffhunk://#diff-e7808df5e3a23e29ccf5e16a66e49c325eab71bd6bfc25c1b98cbc504491c2a0R1-R11) [[2]](diffhunk://#diff-20df9797b39227600adae35b5a6fffed88141b94103e69b3a26b722eabf0898eR1-R11) [[3]](diffhunk://#diff-28d69a08ec478a1891f31f9914cab22b4c654d9a4d35aee03f128f245bd6b568R1-R11) [[4]](diffhunk://#diff-fc3c4df9fb0eba68608bc99ab0c5ae034c392e1b0ec17b4183d4638440ead400R1-R11) [[5]](diffhunk://#diff-126ee684ebf70f6e80485cd96b9aed2d4a49e95751bcfda0427348caae707154R1-R11) [[6]](diffhunk://#diff-96f71b728be48c5079b07da9b8987932f30f0f1257d8a9cdf7afceb9d8a4e113R1-R11)
- Improved type handling in `EntityRenderDispatcher.java` by wrapping the switch result in an explicit cast.
- Clarified lambda parameter types in `FontSet.java` to avoid ambiguity.
- Simplified a generic method call in `VariantSelector.java` by removing an unnecessary cast.

_Logging and Exception Handling:_

- Fixed incorrect variable references in logging statements and exception handling in `PackSelectionScreen.java` and `CreateWorldScreen.java`. [[1]](diffhunk://#diff-49846bb2753c3b6a1d56946b7ee3a59d9af7fdccd3c41391088cf32885b159e8R1-R11) [[2]](diffhunk://#diff-b7654adcf8983cb99cfda48f0bc7dd0bb372f89aa388425a979f68951d01c83cR1-R20)

_Code Structure and Logic:_

- Refactored switch/case blocks in `LevelEventHandler.java` to use explicit code blocks for certain cases, improving readability and correctness.
- Refactored variable usage in `BeaconRenderer.java` to reduce redundancy and clarify variable scope.

(References: [[1]](diffhunk://#diff-bc7a42af0a917334e95bb43c1ac3408e14a03a45ef844e044089d4dc233d5b74L12-R12) [[2]](diffhunk://#diff-c09666b71b500cee7a6d27206ddf1910c82e267cd3b3986256165e73ab313eb8R1-R5) [[3]](diffhunk://#diff-7f825392aa37acd1cee0c2e7b9bb7366ad6eac64f3e6cdd816e156bcb69d30deR7-R12) [[4]](diffhunk://#diff-3402f3dc122aeee0d011f36749d8aa4b2cf7018ca212e95fa015f90b5a0e6001R9-R16) [[5]](diffhunk://#diff-3402f3dc122aeee0d011f36749d8aa4b2cf7018ca212e95fa015f90b5a0e6001R43) [[6]](diffhunk://#diff-d1f0fd1f474b933dc9aeb226989bcab78635260db0e45f35cfc20cf34e051364R1-R31) [[7]](diffhunk://#diff-3771e8d3546b660346b8a3161dcfe2fc97c0981f6e41e63d6761d711c16a7544R1-R94) [[8]](diffhunk://#diff-e7808df5e3a23e29ccf5e16a66e49c325eab71bd6bfc25c1b98cbc504491c2a0R1-R11) [[9]](diffhunk://#diff-20df9797b39227600adae35b5a6fffed88141b94103e69b3a26b722eabf0898eR1-R11) [[10]](diffhunk://#diff-28d69a08ec478a1891f31f9914cab22b4c654d9a4d35aee03f128f245bd6b568R1-R11) [[11]](diffhunk://#diff-fc3c4df9fb0eba68608bc99ab0c5ae034c392e1b0ec17b4183d4638440ead400R1-R11) [[12]](diffhunk://#diff-126ee684ebf70f6e80485cd96b9aed2d4a49e95751bcfda0427348caae707154R1-R11) [[13]](diffhunk://#diff-96f71b728be48c5079b07da9b8987932f30f0f1257d8a9cdf7afceb9d8a4e113R1-R11) [[14]](diffhunk://#diff-440dc04395361d3bdedab6af3b82046c34cd9a6bec7d58d5349ca4e531f3249cR1-R18) [[15]](diffhunk://#diff-893186dc903d73b1618a9eb6e4a097d1d964a9ee2c3455055198a938cfdf5649R1-R11) [[16]](diffhunk://#diff-094ebc9b8c008d0d01868db661fb07af855521cc08de182df2bbd09112fe5553R1-R11) [[17]](diffhunk://#diff-49846bb2753c3b6a1d56946b7ee3a59d9af7fdccd3c41391088cf32885b159e8R1-R11) [[18]](diffhunk://#diff-b7654adcf8983cb99cfda48f0bc7dd0bb372f89aa388425a979f68951d01c83cR1-R20) [[19]](diffhunk://#diff-f8ccae49e518faabbe5b356e1ddc4896878dd1144e0cbcf6097d1c123bff7b8bR1-R29) [[20]](diffhunk://#diff-3310579791062791175cd65c531ed819af7b4aeac5e66dbbeb6c4ffb239e2e27R1-R28)